### PR TITLE
Migrate pre-commit to v4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3
 files: '.py'
 exclude: ".env,.yml,.gitignore,.git,.md,.txt"
-default_stages: [push, commit]
+default_stages: [pre-commit]
 repos:
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.7.10
@@ -10,7 +10,7 @@ repos:
     -  id: bandit
        args: ["-c", "pyproject.toml"]
        name: Bandit
-       stages: [commit]
+       stages: [pre-commit]
        additional_dependencies: ["bandit[toml]"]
        
 -   repo: https://github.com/psf/black
@@ -18,7 +18,7 @@ repos:
     hooks:
     -   id: black
         name: Black
-        stages: [commit]
+        stages: [pre-commit]
         
 -   repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
@@ -27,7 +27,7 @@ repos:
         args: ["--in-place", "--remove-unused-variables",  "--recursive"]
         name: AutoFlake
         description: "Format with AutoFlake"
-        stages: [commit]
+        stages: [pre-commit]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.8
@@ -35,12 +35,14 @@ repos:
       - id: ruff
         name: Ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
-        
+        description: "Fix with ruff"
+        stages: [pre-commit]
+
 -   repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:
     -   id: isort
         name: ISort
         description: "Format with Isort"
-        stages: [commit]
+        stages: [pre-commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,16 @@ repos:
        args: ["-c", "pyproject.toml"]
        name: Bandit
        additional_dependencies: ["bandit[toml]"]
-       
+       stages: [pre-commit]
+
 -   repo: https://github.com/psf/black
     rev: 24.10.0
     hooks:
     -   id: black
         name: Black
-        
+        description: "Format with black"
+        stages: [pre-commit] 
+
 -   repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1
     hooks:
@@ -25,6 +28,7 @@ repos:
         args: ["--in-place", "--remove-unused-variables",  "--recursive"]
         name: AutoFlake
         description: "Format with AutoFlake"
+        stages: [pre-commit]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
@@ -33,6 +37,7 @@ repos:
         name: Ruff
         args: ["--fix", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
         description: "Fix with ruff"
+        stages: [pre-commit]
 
 -   repo: https://github.com/PyCQA/isort
     rev: 5.13.2
@@ -40,4 +45,4 @@ repos:
     -   id: isort
         name: ISort
         description: "Format with Isort"
-
+        stages: [pre-commit]


### PR DESCRIPTION
# Summary

[pre-commit v4](https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0) came out pretty recently, which broke the configuration used in this project. This PR aims to upgrade to the v4 standard.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows (except pre-commit.ci) pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR