### PR TITLE
Remove HTTP 422 responses from OpenAPI schema

### DIFF
--- a/server/core.py
+++ b/server/core.py
@@ -1,11 +1,21 @@
+from __future__ import annotations
+
 import asyncio
 from contextlib import asynccontextmanager
-from typing import Literal, NamedTuple, Optional
+from typing import Literal, NamedTuple, Optional, Generator, TYPE_CHECKING, Any
 
+from itertools import chain
+from collections import OrderedDict
 import asyncpg
-from fastapi import FastAPI
+from fastapi import FastAPI, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import ORJSONResponse
 from typing_extensions import Self
 from utils.config import KanaeConfig
+from fastapi.openapi.utils import get_openapi
+
+if TYPE_CHECKING:
+    from utils.request import RouteRequest
 
 
 class VersionInfo(NamedTuple):
@@ -47,8 +57,53 @@ class Kanae(FastAPI):
             lifespan=self.lifespan,
         )
         self.config = config
+        self.add_exception_handler(
+            RequestValidationError,
+            self.request_validation_error_handler,  # type: ignore
+        )
+
+    ### Exception Handlers
+
+    async def request_validation_error_handler(
+        self, request: RouteRequest, exc: RequestValidationError
+    ) -> ORJSONResponse:
+        errors = ", ".join(
+            OrderedDict.fromkeys(
+                chain.from_iterable(exception["loc"] for exception in exc.errors())
+            ).keys()
+        )
+        return ORJSONResponse(content=f"Field required at: {errors}", status_code=422)
+
+    ### Server-related utilities
 
     @asynccontextmanager
     async def lifespan(self, app: Self):
         async with asyncpg.create_pool(dsn=self.config["postgres_uri"]) as app.pool:
             yield
+
+    def get_db(self) -> Generator[asyncpg.Pool, None, None]:
+        yield self.pool
+
+    def openapi(self) -> dict[str, Any]:
+        if not self.openapi_schema:
+            self.openapi_schema = get_openapi(
+                title=self.title,
+                version=self.version,
+                openapi_version=self.openapi_version,
+                summary=self.summary,
+                description=self.description,
+                terms_of_service=self.terms_of_service,
+                contact=self.contact,
+                license_info=self.license_info,
+                routes=self.routes,
+                webhooks=self.webhooks.routes,
+                tags=self.openapi_tags,
+                servers=self.servers,
+                separate_input_output_schemas=self.separate_input_output_schemas,
+            )
+            for path in self.openapi_schema["paths"].values():
+                for method in path.values():
+                    responses = method.get("responses")
+                    if str(status.HTTP_422_UNPROCESSABLE_ENTITY) in responses:
+                        del responses[str(status.HTTP_422_UNPROCESSABLE_ENTITY)]
+        return self.openapi_schema

--- a/server/core.py
+++ b/server/core.py
@@ -90,16 +90,13 @@ class Kanae(FastAPI):
                 title=self.title,
                 version=self.version,
                 openapi_version=self.openapi_version,
-                summary=self.summary,
                 description=self.description,
                 terms_of_service=self.terms_of_service,
                 contact=self.contact,
                 license_info=self.license_info,
                 routes=self.routes,
-                webhooks=self.webhooks.routes,
                 tags=self.openapi_tags,
                 servers=self.servers,
-                separate_input_output_schemas=self.separate_input_output_schemas,
             )
             for path in self.openapi_schema["paths"].values():
                 for method in path.values():

--- a/server/core.py
+++ b/server/core.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import asynccontextmanager
-from typing import Literal, NamedTuple, Optional, Generator, TYPE_CHECKING, Any
-
-from itertools import chain
 from collections import OrderedDict
+from contextlib import asynccontextmanager
+from itertools import chain
+from typing import TYPE_CHECKING, Any, Generator, Literal, NamedTuple, Optional
+
 import asyncpg
 from fastapi import FastAPI, status
 from fastapi.exceptions import RequestValidationError
+from fastapi.openapi.utils import get_openapi
 from fastapi.responses import ORJSONResponse
 from typing_extensions import Self
 from utils.config import KanaeConfig
-from fastapi.openapi.utils import get_openapi
 
 if TYPE_CHECKING:
     from utils.request import RouteRequest

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -19,7 +19,6 @@ app.include_router(router)
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore
 app.state.limiter = router.limiter
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
# Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR aims to remove the annoying HTTP 422 response within the OpenAPI schema. FastAPI includes this by default for some reason, and since the docs are front-facing and there might be people asking what does the HTTP 422 response even mean, it would be easier and cleaner to entirely remove it. An custom exception handler has also been provided for the HTTP 422 response so if a client does get it, it's not the default response which might give away some important details.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
