### PR TITLE
Rewrite error handlers

### DIFF
--- a/server/utils/errors.py
+++ b/server/utils/errors.py
@@ -12,3 +12,18 @@ class NotFoundException(HTTPException):
     def __init__(self, detail: str = HTTP_404_DETAIL):
         self.status_code = 404
         self.detail = detail
+
+
+class RequestValidationErrorDetails(BaseModel, frozen=True):
+    detail: str
+    context: str
+
+
+class RequestValidationErrorMessage(BaseModel, frozen=True):
+    result: str = "error"
+    errors: list[RequestValidationErrorDetails]
+
+
+class HTTPExceptionMessage(BaseModel, frozen=True):
+    result: str = "error"
+    detail: str


### PR DESCRIPTION
# Summary

This PR rewrites error handlers so it basically covers all of it. Now validation errors are considered to be HTTP 404, and any other HTTP errors are processed, and sent back with a response full of the details, status codes and headers. In addition, HTTP 400 is now passed into the `responses` param within the `Kanae` subclass so they are now generated on the OpenAPI side.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR