### PR TITLE
Redirect index paths to OpenAPI docs

### DIFF
--- a/server/routes/index.py
+++ b/server/routes/index.py
@@ -1,0 +1,9 @@
+from fastapi.responses import RedirectResponse
+from utils.router import KanaeRouter
+
+router = KanaeRouter()
+
+
+@router.get("/")
+async def index() -> RedirectResponse:
+    return RedirectResponse("/docs")

--- a/server/routes/index.py
+++ b/server/routes/index.py
@@ -4,6 +4,6 @@ from utils.router import KanaeRouter
 router = KanaeRouter()
 
 
-@router.get("/")
+@router.get("/", include_in_schema=False)
 async def index() -> RedirectResponse:
     return RedirectResponse("/docs")


### PR DESCRIPTION
# Summary

Standard thing that most APIs do. When requesting from the root path of the application, that path will just redirect back into the docs path.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR