### PR TITLE
Use static Node.js wheels instead of `nodeenv` for Pyright

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 
 # Development libraries
 lefthook>=1.7.22,<2
-pyright>=1.1.355,<2
+pyright[nodejs]>=1.1.355,<2
 ruff>=0.3.4,<1
 tox>=4.14.2,<5

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ no_package=true
 [testenv:lint]
 description = run linting workflows
 deps = 
-    pyright>=1.1.355,<2
+    pyright[nodejs]>=1.1.355,<2
     ruff>=0.3.4,<1
     -r requirements.txt
 commands = 


### PR DESCRIPTION
# Summary

Turns out, installing Pyright through static built Node.js wheels is much faster than creating an Node.js environment on the fly using nodeenv. This speeds up installation, and any subsequent runs has an increase in performance. 

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
