### PR TITLE
Fix broken OpenAPI documentation

### DIFF
--- a/server/routes/events.py
+++ b/server/routes/events.py
@@ -195,7 +195,8 @@ async def create_events(
 
 # We need the member endpoints to be finished in order to implement this
 # Depends on auth
-# @router.post("/events/join")
-# async def join_event(
-#     request: RouteRequest, session: Annotated[SessionContainer, Depends(verify_session())]
-# ): ...
+@router.post("/events/join")
+async def join_event(
+    request: RouteRequest,
+    session: Annotated[SessionContainer, Depends(verify_session())],
+): ...

--- a/server/routes/events.py
+++ b/server/routes/events.py
@@ -110,7 +110,7 @@ async def edit_event(
     request: RouteRequest,
     id: uuid.UUID,
     req: Union[ModifiedEvent, ModifiedEventWithDatetime],
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> EventsWithID:
     """Updates the specified event"""
     query = """
@@ -159,7 +159,7 @@ class DeleteResponse(BaseModel, frozen=True):
 async def delete_event(
     request: RouteRequest,
     id: uuid.UUID,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> DeleteResponse:
     """Deletes the specified event"""
     query = """
@@ -179,7 +179,7 @@ async def delete_event(
 async def create_events(
     request: RouteRequest,
     req: EventsWithCreatorID,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> EventsWithAllID:
     """Creates a new event given the provided data"""
     query = """
@@ -195,7 +195,7 @@ async def create_events(
 
 # We need the member endpoints to be finished in order to implement this
 # Depends on auth
-@router.post("/events/join")
-async def join_event(
-    request: RouteRequest, session: SessionContainer = Depends(verify_session)
-): ...
+# @router.post("/events/join")
+# async def join_event(
+#     request: RouteRequest, session: Annotated[SessionContainer, Depends(verify_session())]
+# ): ...

--- a/server/routes/projects.py
+++ b/server/routes/projects.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 import uuid
 from typing import Annotated, Literal, Optional
@@ -162,7 +160,7 @@ async def edit_project(
     request: RouteRequest,
     id: uuid.UUID,
     req: ModifiedProject,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ):
     """Updates the specified project"""
 
@@ -209,7 +207,7 @@ async def edit_project(
 async def delete_project(
     request: RouteRequest,
     id: uuid.UUID,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ):
     """Deletes the specified project"""
     query = """
@@ -249,7 +247,7 @@ class CreateProject(BaseModel):
 async def create_project(
     request: RouteRequest,
     req: CreateProject,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> PartialProjects:
     """Creates a new project given the provided data"""
     query = """
@@ -306,7 +304,7 @@ class JoinResponse(BaseModel):
 async def join_project(
     request: RouteRequest,
     id: uuid.UUID,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> JoinResponse:
     # The member is authenticated already, aka meaning that there is an existing member in our database
     query = """
@@ -353,7 +351,7 @@ async def bulk_join_project(
     request: RouteRequest,
     id: uuid.UUID,
     req: list[BulkJoinMember],
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> JoinResponse:
     if len(req) > 10:
         raise BadRequestException("Must be less than 10 members")
@@ -393,7 +391,7 @@ async def bulk_join_project(
 async def leave_project(
     request: RouteRequest,
     id: uuid.UUID,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> DeleteResponse:
     query = """
     DELETE FROM project_members
@@ -428,7 +426,7 @@ async def modify_member(
     request: RouteRequest,
     id: uuid.UUID,
     req: UpgradeMemberRole,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ):
     """Undocumented route to just upgrade/demote member role in projects"""
     query = """
@@ -450,7 +448,8 @@ async def modify_member(
 @router.get("/projects/me", responses={200: {"model": PartialProjects}})
 @router.limiter.limit("15/minute")
 async def get_my_projects(
-    request: RouteRequest, session: SessionContainer = Depends(verify_session)
+    request: RouteRequest,
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> list[PartialProjects]:
     """Get all projects associated with the authenticated user"""
     query = """

--- a/server/routes/tags.py
+++ b/server/routes/tags.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Annotated, Optional
 
 from fastapi import Depends, Query
@@ -21,10 +19,6 @@ class Tags(BaseModel):
     id: int
     title: str
     description: str
-
-
-class PartialTags(BaseModel):
-    title: str
 
 
 @router.get("/tags")
@@ -104,7 +98,7 @@ async def edit_tag(request: RouteRequest, id: int, req: ModifiedTag) -> Tags:
 async def delete_tag(
     request: RouteRequest,
     id: int,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> DeleteResponse:
     """Remove specified tag"""
     query = """
@@ -123,7 +117,7 @@ async def delete_tag(
 async def create_tags(
     request: RouteRequest,
     req: ModifiedTag,
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> Tags:
     """Create tag"""
     query = """
@@ -140,7 +134,7 @@ async def create_tags(
 async def bulk_create_tags(
     request: RouteRequest,
     req: list[ModifiedTag],
-    session: SessionContainer = Depends(verify_session),
+    session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> list[Tags]:
     """Bulk-create tags"""
     query = """

--- a/server/utils/router.py
+++ b/server/utils/router.py
@@ -10,21 +10,19 @@ from .config import KanaeConfig
 CONFIG_PATH = Path(__file__).parents[1] / "config.yml"
 
 
-class PartialConfig(BaseModel, frozen=True):
+class PartialConfig(BaseModel):
     redis_uri: str
     ratelimits: list[str]
     dev_mode: bool = False
 
 
 class KanaeRouter(APIRouter):
-    limiter: Limiter
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
         # This isn't my favorite implementation, but will do for now - Noelle
         self._config = self._load_config()
-        self.limiter = Limiter(
+        self.limiter: Limiter = Limiter(
             key_func=get_remote_address,
             storage_uri=self._config.redis_uri,
             default_limits=self._config.ratelimits,  # type: ignore

--- a/server/utils/router.py
+++ b/server/utils/router.py
@@ -10,7 +10,7 @@ from .config import KanaeConfig
 CONFIG_PATH = Path(__file__).parents[1] / "config.yml"
 
 
-class PartialConfig(BaseModel):
+class PartialConfig(BaseModel, frozen=True):
     redis_uri: str
     ratelimits: list[str]
     dev_mode: bool = False


### PR DESCRIPTION
# Summary

Before this PR, I've been working on ensuring that the API documentation works, but ran into a snag when it kept up outputting the same error over and over. If anyone is interested in looking at it, here is the link: https://mystb.in/9e8ebb1b188d84be55.

That point aside, I spent the next 2-3 weeks trying to shim it to work, but that failed. I also did contact the SuperTokens Discord team and the library maintainer for the Python SDK actually reached out to me and helped me with his suggestions. Big thanks to sattvikc for pointing me into the right direction.

Turns out:
1. `Annotated[SessionContainer, Depends(verify_session)]` needed to be used instead of the old way of doing it. This is because FastAPI requires Python 3.9+ instances to use that form of typing rather than the old kind.
2. This was such an easy mistake to make, but there wasnt `()` within `verify_session`. That fixed it up and it finally works.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR