### PR TITLE
Implement administrative and leads user roles

### DIFF
--- a/server/routes/events.py
+++ b/server/routes/events.py
@@ -9,6 +9,7 @@ from supertokens_python.recipe.session.framework.fastapi import verify_session
 from utils.errors import NotFoundException, NotFoundMessage
 from utils.pages import KanaePages, KanaeParams, paginate
 from utils.request import RouteRequest
+from utils.roles import has_any_role
 from utils.router import KanaeRouter
 
 router = KanaeRouter(tags=["Events"])
@@ -100,11 +101,11 @@ class ModifiedEventWithDatetime(ModifiedEvent):
     end_at: datetime.datetime
 
 
-# Depends on scopes
 @router.put(
     "/events/{id}",
     responses={200: {"model": EventsWithID}, 404: {"model": NotFoundMessage}},
 )
+@has_any_role("admin", "leads")
 @router.limiter.limit("10/minute")
 async def edit_event(
     request: RouteRequest,
@@ -150,11 +151,11 @@ class DeleteResponse(BaseModel, frozen=True):
     message: str = "ok"
 
 
-# Depends on scopes
 @router.delete(
     "/events/{id}",
     responses={200: {"model": DeleteResponse}, 404: {"model": NotFoundMessage}},
 )
+@has_any_role("admin", "leads")
 @router.limiter.limit("10/minute")
 async def delete_event(
     request: RouteRequest,
@@ -173,8 +174,8 @@ async def delete_event(
     return DeleteResponse()
 
 
-# Depends on scopes
 @router.post("/events/create", responses={200: {"model": EventsWithAllID}})
+@has_any_role("admin", "leads")
 @router.limiter.limit("15/minute")
 async def create_events(
     request: RouteRequest,

--- a/server/routes/tags.py
+++ b/server/routes/tags.py
@@ -10,6 +10,7 @@ from utils.errors import (
 )
 from utils.request import RouteRequest
 from utils.responses import DeleteResponse
+from utils.roles import has_admin_role
 from utils.router import KanaeRouter
 
 router = KanaeRouter(tags=["Tags"])
@@ -73,8 +74,14 @@ class ModifiedTag(BaseModel):
     "/tags/{id}",
     responses={200: {"model": Tags}, 404: {"model": NotFoundMessage}},
 )
+@has_admin_role()
 @router.limiter.limit("5/minute")
-async def edit_tag(request: RouteRequest, id: int, req: ModifiedTag) -> Tags:
+async def edit_tag(
+    request: RouteRequest,
+    id: int,
+    req: ModifiedTag,
+    session: Annotated[SessionContainer, Depends(verify_session())],
+) -> Tags:
     """Modify specified tag"""
     query = """
     UPDATE tags
@@ -94,6 +101,7 @@ async def edit_tag(request: RouteRequest, id: int, req: ModifiedTag) -> Tags:
     "/tags/{id}",
     responses={200: {"model": DeleteResponse}, 404: {"model": NotFoundMessage}},
 )
+@has_admin_role()
 @router.limiter.limit("5/minute")
 async def delete_tag(
     request: RouteRequest,
@@ -113,6 +121,7 @@ async def delete_tag(
 
 
 @router.post("/tags/create", responses={200: {"model": Tags}})
+@has_admin_role()
 @router.limiter.limit("5/minute")
 async def create_tags(
     request: RouteRequest,
@@ -130,6 +139,7 @@ async def create_tags(
 
 
 @router.post("/tags/bulk-create", responses={200: {"model": list[Tags]}})
+@has_admin_role()
 @router.limiter.limit("1/minute")
 async def bulk_create_tags(
     request: RouteRequest,

--- a/server/routes/user.py
+++ b/server/routes/user.py
@@ -14,7 +14,6 @@ class GetUser(BaseModel):
 router = KanaeRouter(prefix="/users", tags=["Users"])
 
 
-# @has_role()
 @router.get(
     "/get",
     response_model=GetUser,

--- a/server/routes/user.py
+++ b/server/routes/user.py
@@ -14,13 +14,13 @@ class GetUser(BaseModel):
 router = KanaeRouter(prefix="/users", tags=["Users"])
 
 
+# @has_role()
 @router.get(
     "/get",
     response_model=GetUser,
     responses={200: {"model": GetUser}, 404: {"model": NotFound}},
     name="Get users",
 )
-@router.limiter.limit("1/minute")
 async def get_users(request: RouteRequest) -> GetUser:
     query = "SELECT 1;"
     status = await request.app.pool.execute(query)

--- a/server/utils/roles.py
+++ b/server/utils/roles.py
@@ -1,0 +1,101 @@
+# Current scopes:
+# read:
+#   all
+#   projects
+#   events
+#   tags
+# write:
+#   all
+#   events
+#   projects
+# ---------------
+# And current roles: admin, leads
+import functools
+import inspect
+from typing import Any, Callable, Coroutine, Optional, TypeVar
+
+from supertokens_python.exceptions import GeneralError
+from supertokens_python.recipe.session import SessionContainer
+from supertokens_python.recipe.session.exceptions import (
+    ClaimValidationError,
+    InvalidClaimsError,
+)
+from supertokens_python.recipe.userroles import UserRoleClaim
+
+T = TypeVar("T")
+
+Coro = Coroutine[Any, Any, T]
+CoroFunc = Callable[..., Coro[Any]]
+
+
+def validate_parameters(func: CoroFunc):
+    sig = inspect.signature(func)
+    if not sig.parameters.get("session"):
+        raise GeneralError(
+            f"No <session> argument found within function <{func.__name__}>"
+        )
+
+
+def has_role(item: str, /):
+    def decorator(func: CoroFunc) -> CoroFunc:
+        validate_parameters(func)
+
+        @functools.wraps(func)
+        async def wrapper(
+            session: Optional[SessionContainer], *args, **kwargs
+        ) -> CoroFunc:
+            if not session:
+                raise GeneralError("Must have valid session")
+
+            roles = await session.get_claim_value(UserRoleClaim)
+            if not roles or item not in roles:
+                raise InvalidClaimsError(
+                    f"User does not have role <{item}>",
+                    [ClaimValidationError(UserRoleClaim.key, None)],
+                )
+
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def has_any_role(*items: str):
+    def decorator(func: CoroFunc) -> CoroFunc:
+        validate_parameters(func)
+
+        @functools.wraps(func)
+        async def wrapper(
+            session: Optional[SessionContainer], *args, **kwargs
+        ) -> CoroFunc:
+            if not session:
+                raise GeneralError("Must have valid session")
+
+            user_roles = await session.get_claim_value(UserRoleClaim)
+
+            if not user_roles:
+                raise InvalidClaimsError(
+                    f"User does not any roles listed: {', '.join(role for role in items).rstrip()}",
+                    [ClaimValidationError(UserRoleClaim.key, None)],
+                )
+            if not any(role in user_roles for role in items):
+                # May need to be tested more
+                raise InvalidClaimsError(
+                    f"Missing Roles: {', '.join(role for role in items if role not in user_roles).rstrip()}",
+                    [ClaimValidationError(UserRoleClaim.key, None)],
+                )
+
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def has_admin_role():
+    return has_role("admin")
+
+
+def has_leads_role():
+    return has_role("leads")


### PR DESCRIPTION
# Summary

This PR addresses the long-awaited changes of including proper user roles to endpoints. Currently, admins and sig leads have access to some endpoints, and this will expand later on once the ideas are finalized.

This is still an WIP PR as of writing (2/9/2025).

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [ ] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
