### PR TITLE
Fix broken origins for CORS

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -56,6 +56,12 @@ auth:
   # MUST be replaced in production
   website_domain: "http://localhost:5173"
 
+  # Allowed origins for CORS
+  # Leave this as is unless for production
+  allowed_origins:
+    - "http://localhost:5173"
+    - "http://127.0.0.1:5173"
+
   # The backend SuperToken managed or core instance.
   # https://try.supertokens.com can be used for demo purposes, but we will be replacing it with a developer version
   connection_uri: ""

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -23,7 +23,7 @@ app.add_middleware(get_middleware())
 app.include_router(router)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[config["auth"]["website_domain"]],
+    allow_origins=config["auth"]["allowed_origins"],
     allow_credentials=True,
     allow_methods=["GET", "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
     allow_headers=["Content-Type"] + get_all_cors_headers(),


### PR DESCRIPTION
# Summary

This PR finally aims to fix the long standing bug of an incorrect CORS configuration. Now it should be fixed.

> [!WARNING]
> You will most likely need to adjust your configuration in order to allow it to work properly. For current devs, add this within the `auth` key in `server/config.yml`:
> ```yaml
>   allowed_origins:
    - "http://localhost:5173"
    - "http://127.0.0.1:5173"
> ```
> 
> An example of where to put this can be found in the updated `config-example.yml` configuration.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
