### PR TITLE
Implement event attendances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ redis[hiredis]>=5.0.8,<6.0.0
 orjson>=3.10.10,<4
 fastapi-pagination>=0.12.32,<1
 supertokens-python>=0.26.1,<1
+argon2-cffi>=23.1.0,<24
+pybase62>=1.0.0,<2

--- a/server/core.py
+++ b/server/core.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Generator, Optional, Self, Union, Unpack
 
 import asyncpg
 import orjson
+from argon2.exceptions import VerificationError
 from fastapi import Depends, FastAPI, status
 from fastapi.exceptions import HTTPException, RequestValidationError
 from fastapi.openapi.utils import get_openapi
@@ -196,6 +197,10 @@ class Kanae(FastAPI):
         self.add_exception_handler(
             GeneralError,
             self.general_error_handler,  # type: ignore
+        )
+        self.add_exception_handler(
+            VerificationError,
+            self.verification_error_handler,  # type: ignore
         )
 
     # SuperTokens recipes overrides
@@ -416,6 +421,14 @@ class Kanae(FastAPI):
     ) -> ORJSONResponse:
         return ORJSONResponse(
             content={"error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    async def verification_error_handler(
+        self, request: RouteRequest, exc: VerificationError
+    ) -> ORJSONResponse:
+        return ORJSONResponse(
+            content={"error": "Failed to verify, entirely invalid hash"},
+            status_code=status.HTTP_403_FORBIDDEN,
         )
 
     ### Server-related utilities

--- a/server/core.py
+++ b/server/core.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Generator, Optional, Self, Union, Unpack
 
 import asyncpg
 import orjson
+from argon2 import PasswordHasher
 from argon2.exceptions import VerificationError
 from fastapi import Depends, FastAPI, status
 from fastapi.exceptions import HTTPException, RequestValidationError
@@ -52,7 +53,6 @@ from supertokens_python.recipe.emailpassword.interfaces import (
 )
 # isort: on
 
-from argon2 import PasswordHasher
 from utils.config import KanaeConfig
 from utils.errors import (
     HTTPExceptionMessage,

--- a/server/core.py
+++ b/server/core.py
@@ -51,6 +51,7 @@ from supertokens_python.recipe.emailpassword.interfaces import (
 )
 # isort: on
 
+from argon2 import PasswordHasher
 from utils.config import KanaeConfig
 from utils.errors import (
     HTTPExceptionMessage,
@@ -183,6 +184,7 @@ class Kanae(FastAPI):
             mode="asgi",
         )
         self.config = config
+        self.ph = PasswordHasher()
         self.add_exception_handler(
             HTTPException,
             self.http_exception_handler,  # type: ignore

--- a/server/migrations/V4__attendance_hash.sql
+++ b/server/migrations/V4__attendance_hash.sql
@@ -1,0 +1,11 @@
+-- Revision Version: V4
+-- Revises: V3
+-- Creation Date: 2025-02-10 05:03:02.890358+00:00 UTC
+-- Reason: attendance_hash
+
+ALTER TABLE IF EXISTS events ADD COLUMN attendance_hash TEXT;
+ALTER TABLE IF EXISTS events ADD COLUMN attendance_code TEXT;
+
+-- Column to check whether a user either planned to attend or has attended the event
+ALTER TABLE IF EXISTS events_members ADD COLUMN planned BOOLEAN DEFAULT NULL;
+ALTER TABLE IF EXISTS events_members ADD COLUMN attended BOOLEAN DEFAULT FALSE;

--- a/server/migrations/V4__attendance_hash.sql
+++ b/server/migrations/V4__attendance_hash.sql
@@ -6,6 +6,9 @@
 ALTER TABLE IF EXISTS events ADD COLUMN attendance_hash TEXT;
 ALTER TABLE IF EXISTS events ADD COLUMN attendance_code TEXT;
 
+-- We need to make sure that we are storing the correct timezone for events
+ALTER TABLE IF EXISTS events ADD COLUMN timezone TEXT DEFAULT 'UTC';
+
 -- Column to check whether a user either planned to attend or has attended the event
 ALTER TABLE IF EXISTS events_members ADD COLUMN planned BOOLEAN DEFAULT NULL;
 ALTER TABLE IF EXISTS events_members ADD COLUMN attended BOOLEAN DEFAULT FALSE;

--- a/server/routes/events.py
+++ b/server/routes/events.py
@@ -1,18 +1,56 @@
 import datetime
 import uuid
+from dataclasses import asdict
 from typing import Annotated, Literal, Optional, Union
 
-from fastapi import Depends, Query
-from pydantic import BaseModel
+import asyncpg
+import base62
+from argon2 import Parameters
+from argon2.low_level import Type
+from fastapi import Depends, Query, status
+from fastapi.exceptions import HTTPException
+from pydantic import BaseModel, model_validator
 from supertokens_python.recipe.session import SessionContainer
 from supertokens_python.recipe.session.framework.fastapi import verify_session
-from utils.errors import NotFoundException, NotFoundMessage
+from typing_extensions import Self
+from utils.errors import HTTPExceptionMessage, NotFoundException, NotFoundMessage
 from utils.pages import KanaePages, KanaeParams, paginate
 from utils.request import RouteRequest
+from utils.responses import JoinResponse
 from utils.roles import has_any_role
 from utils.router import KanaeRouter
 
+_TYPE_TO_NAME = {Type.ID: "argon2id", Type.I: "argon2i", Type.D: "argon2d"}
+_REQUIRED_KEYS = ("v", "m", "t", "p")
+_CONDENSED_KEYS = {
+    "version": "v",
+    "memory_cost": "m",
+    "time_cost": "t",
+    "parallelism": "p",
+}
+
 router = KanaeRouter(tags=["Events"])
+
+
+# Basically to take the params set within argon2.PasswordHasher, and compile them into arguments for validation purposes
+def compile_params(params: Parameters) -> str:
+    def _join_parts(part: tuple[str, str]) -> str:
+        return "=".join(part)
+
+    parts = [_TYPE_TO_NAME[params.type]]
+    sorted_parts = sorted(
+        [
+            (_CONDENSED_KEYS[key], str(param))
+            for key, param in asdict(params).items()
+            if key not in ("type", "salt_len", "hash_len")
+        ],
+        key=lambda x: _REQUIRED_KEYS.index(x[0]),
+    )
+
+    parts.extend(
+        [_join_parts(sorted_parts[0]), ",".join(map(_join_parts, sorted_parts[1:]))]
+    )
+    return f"${'$'.join(parts)}$"
 
 
 class Events(BaseModel):
@@ -137,14 +175,28 @@ async def edit_event(
         RETURNING *;
         """
 
-    rows = await request.app.pool.fetchrow(
-        query, id, session.get_user_id(), *req.model_dump().values()
+    update_hash_query = (
+        "UPDATE events SET attendance_hash = $3 WHERE id = $1 AND creator_id = $2;"
     )
-    if not rows:
-        raise NotFoundException(
-            detail="Resource cannot be updated"
-        )  # Not sure if this is correct by RFC 9110 standards
-    return EventsWithID(**dict(rows))
+    async with request.app.pool.acquire() as connection:
+        rows = await connection.fetchrow(
+            query, id, session.get_user_id(), *req.model_dump().values()
+        )
+        if not rows:
+            raise NotFoundException(
+                detail="Resource cannot be updated"
+            )  # Not sure if this is correct by RFC 9110 standards
+
+        full_hash = compile_params(request.app.ph._parameters) + rows["attendance_hash"]
+        if request.app.ph.check_needs_rehash(full_hash):
+            await connection.execute(
+                update_hash_query,
+                id,
+                session.get_user_id(),
+                request.app.ph.hash(str(id)),
+            )
+
+        return EventsWithID(**dict(rows))
 
 
 class DeleteResponse(BaseModel, frozen=True):
@@ -174,12 +226,15 @@ async def delete_event(
     return DeleteResponse()
 
 
-@router.post("/events/create", responses={200: {"model": EventsWithAllID}})
+@router.post(
+    "/events/create",
+    responses={200: {"model": EventsWithAllID}, 409: {"model": HTTPExceptionMessage}},
+)
 @has_any_role("admin", "leads")
 @router.limiter.limit("15/minute")
 async def create_events(
     request: RouteRequest,
-    req: EventsWithCreatorID,
+    req: Events,
     session: Annotated[SessionContainer, Depends(verify_session())],
 ) -> EventsWithAllID:
     """Creates a new event given the provided data"""
@@ -188,16 +243,129 @@ async def create_events(
     VALUES ($1, $2, $3, $4, $5, $6, $7)
     RETURNING *;
     """
-    rows = await request.app.pool.fetchrow(
-        query, *req.model_dump().values(), session.get_user_id()
-    )
-    return EventsWithAllID(**dict(rows))
+    attendance_query = """
+    UPDATE events
+    SET 
+        attendance_hash = $3,
+        attendance_code = $4
+    WHERE id = $1 AND creator_id = $2;
+    """
+    async with request.app.pool.acquire() as connection:
+        tr = connection.transaction()
+        await tr.start()
+
+        try:
+            rows = await request.app.pool.fetchrow(
+                query, *req.model_dump().values(), session.get_user_id()
+            )
+            encoded_hash = request.app.ph.hash(str(rows["id"]))
+
+            # note that the salt is stored along with the hash
+            await request.app.pool.execute(
+                attendance_query,
+                rows["id"],
+                session.get_user_id(),
+                "$".join(encoded_hash.split("$")[-2:]),
+                base62.encodebytes(encoded_hash.split("$")[-1].encode("utf-8")),
+            )
+        except asyncpg.UniqueViolationError:
+            await tr.rollback()
+            raise HTTPException(
+                detail="Requested project already exists",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+        else:
+            await tr.commit()
+            return EventsWithAllID(**dict(rows))
 
 
-# We need the member endpoints to be finished in order to implement this
-# Depends on auth
-@router.post("/events/join")
+# TODO: add ratelimiting
+@router.post(
+    "/events/{id}/join",
+    responses={
+        200: {"model": JoinResponse},
+        404: {"model": NotFoundMessage},
+        409: {"model": HTTPExceptionMessage},
+    },
+)
 async def join_event(
     request: RouteRequest,
+    id: uuid.UUID,
     session: Annotated[SessionContainer, Depends(verify_session())],
-): ...
+) -> JoinResponse:
+    """Registers and joins an upcoming event"""
+    query = """
+    SELECT start_at, end_at FROM events WHERE id = $1;
+    """
+
+    insert_query = """
+    INSERT INTO events_members (event_id, member_id, planned)
+    VALUES ($1, $2, TRUE);
+    """
+    async with request.app.pool.acquire() as connection:
+        tr = connection.transaction
+
+        rows = await connection.fetchrow(query, id)
+        if not rows:
+            raise NotFoundException("Should not happen")
+
+        # TODO: Check to make sure that you can't join an event after the end time.
+        await tr.start()
+
+        try:
+            await connection.execute(insert_query, id, session.get_user_id())
+        except asyncpg.UniqueViolationError:
+            await tr.rollback()
+            raise HTTPException(
+                detail="Authenticated member has already joined the requested event",
+                status_code=status.HTTP_409_CONFLICT,
+            )
+        else:
+            await tr.commit()
+            return JoinResponse()
+
+
+class VerifiedResponse(BaseModel):
+    message: str = "Successfully verified attendance!"
+
+
+class VerifyRequest(BaseModel):
+    code: str
+
+    @model_validator(mode="before")
+    def check_code_length(self) -> Self:
+        if len(self.code) > 8:
+            raise ValueError("Must be 8 characters or less")
+        return self
+
+
+# TODO: add 403 model for when the hash is invald.
+# TODO: add ratelimiting
+@router.post("/events/{id}/verify", responses={200: {"model": VerifiedResponse}})
+async def verify_attendance(
+    request: RouteRequest,
+    id: uuid.UUID,
+    req: VerifyRequest,
+    session: Annotated[SessionContainer, Depends(verify_session())],
+):
+    """Verify an authenticated user's attendance to the requested event"""
+    query = "SELECT attendance_hash FROM events WHERE substring(attendance_code for 8) = $1;"
+    possible_hash = await request.app.pool.fetchval(query, req.code)
+    if not possible_hash:
+        raise NotFoundException(
+            detail="Apparently there is no attendance hash... Hmmmm.... this should never happen"
+        )
+
+    full_hash = compile_params(request.app.ph._parameters) + possible_hash
+
+    # should raise a error directly, which would need to be handled.
+    if request.app.ph.verify(full_hash, str(id)):
+        verify_query = """
+        INSERT INTO events_members (event_id, member_id, attended)
+        VALUES ($1, $2, TRUE)
+        ON CONFLICT (event_id, member_id) DO UPDATE
+        SET attended = excluded.attended;
+        """
+        await request.app.pool.execute(verify_query, id, session.get_user_id())
+
+    return VerifiedResponse()

--- a/server/routes/projects.py
+++ b/server/routes/projects.py
@@ -16,7 +16,7 @@ from utils.errors import (
 )
 from utils.pages import KanaePages, KanaeParams, paginate
 from utils.request import RouteRequest
-from utils.responses import DeleteResponse
+from utils.responses import DeleteResponse, JoinResponse
 from utils.roles import has_admin_role, has_any_role
 from utils.router import KanaeRouter
 
@@ -313,10 +313,6 @@ async def create_project(
                 await tr.commit()
 
         return PartialProjects(**dict(project_rows), tags=req.tags)
-
-
-class JoinResponse(BaseModel):
-    message: str
 
 
 @router.post(

--- a/server/utils/responses.py
+++ b/server/utils/responses.py
@@ -3,3 +3,7 @@ from pydantic import BaseModel
 
 class DeleteResponse(BaseModel):
     message: str = "ok"
+
+
+class JoinResponse(BaseModel):
+    message: str = "Successfully joined"

--- a/server/utils/responses.py
+++ b/server/utils/responses.py
@@ -7,3 +7,7 @@ class DeleteResponse(BaseModel):
 
 class JoinResponse(BaseModel):
     message: str = "Successfully joined"
+
+
+class VerifyFailedResponse(BaseModel):
+    message: str = "Failed to verify, entirely invalid hash"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,9 @@
 version = 1
 requires-python = ">=3.9, <4.0"
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "kanae"
 version = "0.1.0"


### PR DESCRIPTION
# Summary

This has been a long-awaited feature, and was originally pitched to Atom, Steven and Akhil during winter break of 2024-2025. The idea is that there is now a unique attendance code that is available, which would streamline the experience of signing into workshops by providing an 8-digit unique code to enter. Unlike the previous implementations, all attendance codes are hashed via [Argon2id](https://en.wikipedia.org/wiki/Argon2), and then passed through a Base 62 encoder to provide easy to enter alphanumberic codes.

The code that will be stored is the full length, but the ones provided to members are only 8-digit long. They are additionally hashed, so there is effectively no point of trying to work around this system as you always do not know the full encoded hash, and then on top of all of that, there is the fact that argon2id basically is nearly impossible to crack (even better than SHA-256 and PBKDF2).

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [ ] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
