### PR TITLE
Implement better production logging

### DIFF
--- a/server/launcher.py
+++ b/server/launcher.py
@@ -12,7 +12,7 @@ from slowapi.errors import RateLimitExceeded
 from starlette.middleware.cors import CORSMiddleware
 from supertokens_python import get_all_cors_headers
 from supertokens_python.framework.fastapi import get_middleware
-from utils.config import KanaeConfig
+from utils.config import KanaeConfig, KanaeUvicornConfig
 from uvicorn.supervisors import Multiprocess
 
 config_path = Path(__file__).parent / "config.yml"
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     use_workers = not args.no_workers
     worker_count = args.workers
 
-    config = uvicorn.Config(
+    config = KanaeUvicornConfig(
         "launcher:app", port=args.port, host=args.host, access_log=True
     )
 

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -21,6 +21,11 @@ LOG_LEVELS: dict[str, int] = {
 }
 
 
+### Color Formatter for Logging
+
+
+# Directly pulled from discord.py
+# https://github.com/Rapptz/discord.py/blob/0e4f06103ee20d06fb6c0d64f75b1fc475905b95/discord/utils.py#L1306
 class _ColourFormatter(logging.Formatter):
     # ANSI codes are a bit weird to decipher if you're unfamiliar with them, so here's a refresher
     # It starts off with a format like \x1b[XXXm where XXX is a semicolon separated list of commands
@@ -64,6 +69,9 @@ class _ColourFormatter(logging.Formatter):
         return output
 
 
+### YAML based memory configuration
+
+
 class KanaeConfig(Generic[_T]):
     def __init__(self, path: Path):
         self.path = path
@@ -100,9 +108,14 @@ class KanaeConfig(Generic[_T]):
         return self._config
 
 
+### Overridden and Custom Uvicorn Configuration
+
+
 class KanaeUvicornConfig(UvicornConfig):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    ### Private utilities
 
     def _determine_level(self, level: Optional[Union[str, int]]) -> int:
         # Force return info level
@@ -114,12 +127,14 @@ class KanaeUvicornConfig(UvicornConfig):
         else:
             return level
 
+    # Pulled from https://github.com/Rapptz/discord.py/blob/0e4f06103ee20d06fb6c0d64f75b1fc475905b95/discord/utils.py#L1285
     def _is_docker(self) -> bool:
         path = "/proc/self/cgroup"
         return os.path.exists("/.dockerenv") or (
             os.path.isfile(path) and any("docker" in line for line in open(path))
         )
 
+    # Pulled from https://github.com/Rapptz/discord.py/blob/0e4f06103ee20d06fb6c0d64f75b1fc475905b95/discord/utils.py#L1290
     def _stream_supports_colour(self, stream: Any) -> bool:
         is_a_tty = hasattr(stream, "isatty") and stream.isatty()
 
@@ -134,6 +149,8 @@ class KanaeUvicornConfig(UvicornConfig):
         # ANSICON checks for things like ConEmu
         # WT_SESSION checks if this is Windows Terminal
         return is_a_tty and ("ANSICON" in os.environ or "WT_SESSION" in os.environ)
+
+    ### Logging override
 
     def configure_logging(self) -> None:
         max_bytes = 32 * 1024 * 1024  # 32 MiB

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -1,9 +1,67 @@
+import logging
+import os
+import sys
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, Union, overload
 
 import yaml
+from uvicorn.config import Config as UvicornConfig
+from uvicorn.logging import TRACE_LOG_LEVEL
 
 _T = TypeVar("_T")
+
+LOG_LEVELS: dict[str, int] = {
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+    "trace": TRACE_LOG_LEVEL,
+}
+
+
+class _ColourFormatter(logging.Formatter):
+    # ANSI codes are a bit weird to decipher if you're unfamiliar with them, so here's a refresher
+    # It starts off with a format like \x1b[XXXm where XXX is a semicolon separated list of commands
+    # The important ones here relate to colour.
+    # 30-37 are black, red, green, yellow, blue, magenta, cyan and white in that order
+    # 40-47 are the same except for the background
+    # 90-97 are the same but "bright" foreground
+    # 100-107 are the same as the bright ones but for the background.
+    # 1 means bold, 2 means dim, 0 means reset, and 4 means underline.
+
+    LEVEL_COLOURS = [
+        (logging.DEBUG, "\x1b[40;1m"),
+        (logging.INFO, "\x1b[34;1m"),
+        (logging.WARNING, "\x1b[33;1m"),
+        (logging.ERROR, "\x1b[31m"),
+        (logging.CRITICAL, "\x1b[41m"),
+    ]
+
+    FORMATS = {
+        level: logging.Formatter(
+            f"\x1b[30;1m%(asctime)s\x1b[0m {colour}%(levelname)-8s\x1b[0m \x1b[0m %(message)s",
+            "%Y-%m-%d %H:%M:%S",
+        )
+        for level, colour in LEVEL_COLOURS
+    }
+
+    def format(self, record):
+        formatter = self.FORMATS.get(record.levelno)
+        if formatter is None:
+            formatter = self.FORMATS[logging.DEBUG]
+
+        # Override the traceback to always print in red
+        if record.exc_info:
+            text = formatter.formatException(record.exc_info)
+            record.exc_text = f"\x1b[31m{text}\x1b[0m"
+
+        output = formatter.format(record)
+
+        # Remove the cache layer
+        record.exc_text = None
+        return output
 
 
 class KanaeConfig(Generic[_T]):
@@ -40,3 +98,84 @@ class KanaeConfig(Generic[_T]):
 
     def all(self) -> dict[str, Union[_T, Any]]:
         return self._config
+
+
+class KanaeUvicornConfig(UvicornConfig):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _determine_level(self, level: Optional[Union[str, int]]) -> int:
+        # Force return info level
+        if not level:
+            return logging.INFO
+
+        if isinstance(level, str):
+            return LOG_LEVELS[level]
+        else:
+            return level
+
+    def _is_docker(self) -> bool:
+        path = "/proc/self/cgroup"
+        return os.path.exists("/.dockerenv") or (
+            os.path.isfile(path) and any("docker" in line for line in open(path))
+        )
+
+    def _stream_supports_colour(self, stream: Any) -> bool:
+        is_a_tty = hasattr(stream, "isatty") and stream.isatty()
+
+        # Pycharm and Vscode support colour in their inbuilt editors
+        if "PYCHARM_HOSTED" in os.environ or os.environ.get("TERM_PROGRAM") == "vscode":
+            return is_a_tty
+
+        if sys.platform != "win32":
+            # Docker does not consistently have a tty attached to it
+            return is_a_tty or self._is_docker()
+
+        # ANSICON checks for things like ConEmu
+        # WT_SESSION checks if this is Windows Terminal
+        return is_a_tty and ("ANSICON" in os.environ or "WT_SESSION" in os.environ)
+
+    def configure_logging(self) -> None:
+        max_bytes = 32 * 1024 * 1024  # 32 MiB
+        logging.addLevelName(TRACE_LOG_LEVEL, "TRACE")
+
+        # Apparently the main logs are redirected to this module...
+        root = logging.getLogger("uvicorn.error")
+        access_logger = logging.getLogger("uvicorn.access")
+        asgi_logger = logging.getLogger("uvicorn.asgi")
+
+        level = self._determine_level(self.log_level)
+
+        handler = logging.StreamHandler()
+
+        if self.access_log:
+            file_handler = RotatingFileHandler(
+                filename="kanae-access.log",
+                encoding="utf-8",
+                mode="w",
+                maxBytes=max_bytes,
+                backupCount=5,
+            )
+            access_logger.setLevel(level)
+            access_logger.addHandler(handler)
+
+            if not self._is_docker():
+                access_logger.addHandler(file_handler)
+
+        if isinstance(handler, logging.StreamHandler) and self._stream_supports_colour(
+            handler.stream
+        ):
+            formatter = _ColourFormatter()
+        else:
+            dt_fmt = "%Y-%m-%d %H:%M:%S"
+            formatter = logging.Formatter(
+                "[{asctime}] [{levelname:<8}]{:^4}{message}", dt_fmt, style="{"
+            )
+
+        handler.setFormatter(formatter)
+
+        root.setLevel(level)
+        root.addHandler(handler)
+
+        asgi_logger.setLevel(level)
+        asgi_logger.addHandler(handler)


### PR DESCRIPTION
# Summary

It turns out that uvicorn basically doesn't even bother to try with logging. So now, if you just run `python3 server/launcher.py --no-workers` (basically on production), a whole new logging format is used, and it includes better date and time support.

Inspiration for the designs and implementation is based off of [discord.py's logging setup](https://github.com/Rapptz/discord.py/blob/0e4f06103ee20d06fb6c0d64f75b1fc475905b95/discord/utils.py#L1350).

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
