### PR TITLE
Force Uvicorn to use uvloop/winloop

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ lefthook>=1.11.5,<2
 pyright[nodejs]>=1.1.398,<2
 ruff>=0.11.2,<1
 tox>=4.25.0,<5
+
+# Additional utils only used for development
+colorama>=0.4.6,<5 ; sys_platform == "win32"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 fastapi>=0.115.12,<1
-uvicorn[standard]>=0.34.0,<1
+uvicorn>=0.34.0,<1
+httptools>=0.6.4,<1
+uvloop>=0.21.0,<1 ; sys_platform != "win32"
+winloop>=0.1.8,<1 ; sys_platform == "win32"
 asyncpg>=0.30.0,<1
 typing-extensions>=4.13.0,<5
 slowapi>=0.1.9,<1
@@ -10,3 +13,5 @@ supertokens-python>=0.29.0,<1
 argon2-cffi>=23.1.0,<24
 pybase62>=1.0.0,<2
 email-validator>=2.2.0,<3
+PyYAML>=6.0.2,<7
+watchfiles>=1.0.5

--- a/server/core.py
+++ b/server/core.py
@@ -128,7 +128,6 @@ class Kanae(FastAPI):
             dependencies=[Depends(self.get_db)],
             default_response_class=ORJSONResponse,
             responses={400: {"model": RequestValidationErrorResponse}},
-            loop=self.loop,
             redoc_url="/docs",
             docs_url=None,
             lifespan=self.lifespan,

--- a/server/core.py
+++ b/server/core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Generator, Optional, Self, Union, Unpack
@@ -115,12 +114,8 @@ class Kanae(FastAPI):
     def __init__(
         self,
         *,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
         config: KanaeConfig,
     ):
-        self.loop: asyncio.AbstractEventLoop = (
-            loop or asyncio.get_event_loop_policy().get_event_loop()
-        )
         super().__init__(
             title=__title__,
             description=__description__,

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -77,6 +77,4 @@ if __name__ == "__main__":
     else:
         runner = server
 
-        # Apparently this doesn't have it's own signal handler
-
     runner.run()

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -72,7 +72,6 @@ if __name__ == "__main__":
     if use_workers:
         config.workers = worker_count
 
-        # Needs to be fixed
         runner = Multiprocess(config, target=server.multi_run, sockets=[sock])
     else:
         runner = server

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -117,7 +117,7 @@ class KanaeUvicornConfig(UvicornConfig):
         self.loop = "auto"
 
     def setup_event_loop(self) -> None:
-        return
+        pass
 
     ### Private utilities
 

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -114,6 +114,10 @@ class KanaeConfig(Generic[_T]):
 class KanaeUvicornConfig(UvicornConfig):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.loop = "auto"
+
+    def setup_event_loop(self) -> None:
+        return
 
     ### Private utilities
 

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -114,7 +114,6 @@ class KanaeConfig(Generic[_T]):
 class KanaeUvicornConfig(UvicornConfig):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.loop = "auto"
 
     def setup_event_loop(self) -> None:
         pass

--- a/server/utils/handler.py
+++ b/server/utils/handler.py
@@ -4,17 +4,14 @@ import asyncio
 import socket
 from typing import TYPE_CHECKING, Optional
 
-from uvicorn.server import Server
-
 if TYPE_CHECKING:
-    from core import Kanae
+    from .server import KanaeUvicornServer
 
 
 class InterruptHandler:
     def __init__(
-        self, core: Kanae, server: Server, sockets: Optional[list[socket.socket]] = None
+        self, server: KanaeUvicornServer, sockets: Optional[list[socket.socket]] = None
     ):
-        self.core = core
         self.server = server
         self.sockets = sockets
         self._task: Optional[asyncio.Task] = None
@@ -23,6 +20,6 @@ class InterruptHandler:
         if self._task:
             raise KeyboardInterrupt
 
-        self._task = self.core.loop.create_task(
+        self._task = self.server.loop.create_task(
             self.server.shutdown(sockets=self.sockets)
         )

--- a/server/utils/server.py
+++ b/server/utils/server.py
@@ -18,15 +18,13 @@ else:
 class KanaeUvicornServer(uvicorn.Server):
     def __init__(self, config: KanaeUvicornConfig):
         super().__init__(config)
-        self.loop = new_event_loop()
-
-    def _register_signals(self, sockets: Optional[list[socket.socket]] = None) -> None:
-        handler = InterruptHandler(server=self, sockets=sockets)
-        self.loop.add_signal_handler(signal.SIGINT, handler)
-        self.loop.add_signal_handler(signal.SIGTERM, handler)
 
     def run(self, sockets: Optional[list[socket.socket]] = None) -> None:
-        self._register_signals(sockets)
+        self.loop = new_event_loop()
+        handler = InterruptHandler(server=self, sockets=sockets)
+
+        self.loop.add_signal_handler(signal.SIGINT, handler)
+        self.loop.add_signal_handler(signal.SIGTERM, handler)
         return run(self.serve(sockets=sockets))
 
     def multi_run(self, sockets: Optional[list[socket.socket]] = None) -> None:

--- a/server/utils/server.py
+++ b/server/utils/server.py
@@ -1,0 +1,33 @@
+# Wrapper around uvicorn.Server to handle uvloop/winloop
+import asyncio
+import os
+import signal
+import socket
+from typing import Optional
+
+import uvicorn
+from utils.config import KanaeUvicornConfig
+from utils.handler import InterruptHandler
+
+if os.name == "nt":
+    from winloop import new_event_loop, run
+else:
+    from uvloop import new_event_loop, run
+
+
+class KanaeUvicornServer(uvicorn.Server):
+    def __init__(self, config: KanaeUvicornConfig):
+        super().__init__(config)
+        self.loop = new_event_loop()
+
+    def _register_signals(self, sockets: Optional[list[socket.socket]] = None) -> None:
+        handler = InterruptHandler(server=self, sockets=sockets)
+        self.loop.add_signal_handler(signal.SIGINT, handler)
+        self.loop.add_signal_handler(signal.SIGTERM, handler)
+
+    def run(self, sockets: Optional[list[socket.socket]] = None) -> None:
+        self._register_signals(sockets)
+        return run(self.serve(sockets=sockets))
+
+    def multi_run(self, sockets: Optional[list[socket.socket]] = None) -> None:
+        return asyncio.run(self.serve(sockets=sockets))


### PR DESCRIPTION
# Summary

Turns out, Uvicorn apparently uses the outdated and deprecated `uvloop.EventLoopPolicy` and using that to [install uvloop](<https://github.com/encode/uvicorn/blob/master/uvicorn/loops/uvloop.py#L7C5-L7C60>). Btw, that hasn't been updated for 3 years, and uvloop rolled out the new usage of `uvloop.run()` (like `asyncio.run()`) in https://github.com/MagicStack/uvloop/pull/570 (and released in v0.18.0). This, is just egregious code, and somehow **no one** has pointed that out yet. Instead of relying on `asyncio.WindowsSelectorEventLoopPolicy()`, [winloop](<https://github.com/Vizonex/Winloop>) is used instead. Supposely, winloop offers an 8.6% increase in performance compared to the previously mentioned policy.

In addition, `Config.setup_event_loop` has been completely overriden to effectively do nothing. The fact that they are still using outdated code that has been marked as deprecated for over 2 years is just extremely concerning to me.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc), 
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
