### PR TITLE
Use Gunicorn for process management instead of Uvicorn

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ EXPOSE 9555
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-CMD ["python3", "/kanae/server/launcher.py", "--no-workers"]
+CMD ["python3", "/kanae/server/launcher.py"]
 
 STOPSIGNAL SIGTERM
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,8 @@
+import os
+
+bind = ["127.0.0.1:8000", "unix:/tmp/gunicorn.sock"]
+chdir = "server"
+workers = os.cpu_count() or 1
+worker_class = "utils.uvicorn.workers.KanaeWorker"
+
+wsgi_app = "launcher:app"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ tox>=4.25.0,<5
 
 # Additional utils only used for development
 colorama>=0.4.6,<5 ; sys_platform == "win32"
+watchfiles>=1.0.5,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pybase62>=1.0.0,<2
 email-validator>=2.2.0,<3
 PyYAML>=6.0.2,<7
 watchfiles>=1.0.5
+gunicorn>=23.0.0,<24

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ argon2-cffi>=23.1.0,<24
 pybase62>=1.0.0,<2
 email-validator>=2.2.0,<3
 PyYAML>=6.0.2,<7
-watchfiles>=1.0.5
 gunicorn>=23.0.0,<24

--- a/server/core.py
+++ b/server/core.py
@@ -122,6 +122,7 @@ class Kanae(FastAPI):
             version=__version__,
             dependencies=[Depends(self.get_db)],
             default_response_class=ORJSONResponse,
+            http="httptools",
             responses={400: {"model": RequestValidationErrorResponse}},
             redoc_url="/docs",
             docs_url=None,

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -32,8 +32,8 @@ app.state.limiter = router.limiter
 if __name__ == "__main__":
     config = KanaeUvicornConfig(
         "launcher:app",
-        port=config["kanae"]["host"],
-        host=config["kanae"]["port"],
+        port=config["kanae"]["port"],
+        host=config["kanae"]["host"],
         access_log=True,
     )
 

--- a/server/utils/handler.py
+++ b/server/utils/handler.py
@@ -5,7 +5,7 @@ import socket
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from .server import KanaeUvicornServer
+    from utils.uvicorn.server import KanaeUvicornServer
 
 
 class InterruptHandler:

--- a/server/utils/uvicorn/server.py
+++ b/server/utils/uvicorn/server.py
@@ -1,5 +1,4 @@
 # Wrapper around uvicorn.Server to handle uvloop/winloop
-import asyncio
 import os
 import signal
 import socket
@@ -26,6 +25,3 @@ class KanaeUvicornServer(uvicorn.Server):
         self.loop.add_signal_handler(signal.SIGINT, handler)
         self.loop.add_signal_handler(signal.SIGTERM, handler)
         return run(self.serve(sockets=sockets))
-
-    def multi_run(self, sockets: Optional[list[socket.socket]] = None) -> None:
-        return asyncio.run(self.serve(sockets=sockets))

--- a/server/utils/uvicorn/workers.py
+++ b/server/utils/uvicorn/workers.py
@@ -1,0 +1,131 @@
+"""
+Copyright © 2017-present, [Encode OSS Ltd](https://www.encode.io/).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from typing import Any
+
+from gunicorn.arbiter import Arbiter
+from gunicorn.workers.base import Worker
+from uvicorn.config import Config
+from uvicorn.server import Server
+
+if os.name == "nt":
+    from winloop import run
+else:
+    from uvloop import run
+
+
+class KanaeWorker(Worker):
+    """
+    Customized uvicorn worker that forces uvloop/winloop and httptools.
+    Also modifies code to remove setting the event loop.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        logger = logging.getLogger("uvicorn.error")
+        logger.handlers = self.log.error_log.handlers
+        logger.setLevel(self.log.error_log.level)
+        logger.propagate = False
+
+        logger = logging.getLogger("uvicorn.access")
+        logger.handlers = self.log.access_log.handlers
+        logger.setLevel(self.log.access_log.level)
+        logger.propagate = False
+
+        config_kwargs: dict = {
+            "app": None,
+            "http": "httptools",
+            "log_config": None,
+            "timeout_keep_alive": self.cfg.keepalive,
+            "timeout_notify": self.timeout,
+            "callback_notify": self.callback_notify,
+            "limit_max_requests": self.max_requests,
+            "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
+        }
+
+        if self.cfg.is_ssl:
+            ssl_kwargs = {
+                "ssl_keyfile": self.cfg.ssl_options.get("keyfile"),
+                "ssl_certfile": self.cfg.ssl_options.get("certfile"),
+                "ssl_keyfile_password": self.cfg.ssl_options.get("password"),
+                "ssl_version": self.cfg.ssl_options.get("ssl_version"),
+                "ssl_cert_reqs": self.cfg.ssl_options.get("cert_reqs"),
+                "ssl_ca_certs": self.cfg.ssl_options.get("ca_certs"),
+                "ssl_ciphers": self.cfg.ssl_options.get("ciphers"),
+            }
+            config_kwargs.update(ssl_kwargs)
+
+        if self.cfg.settings["backlog"].value:
+            config_kwargs["backlog"] = self.cfg.settings["backlog"].value
+
+        self.config = Config(**config_kwargs)
+
+    def init_signals(self) -> None:
+        # Reset signals so Gunicorn doesn't swallow subprocess return codes
+        # other signals are set up by Server.install_signal_handlers()
+        # See: https://github.com/encode/uvicorn/issues/894
+        for s in self.SIGNALS:
+            signal.signal(s, signal.SIG_DFL)
+
+        signal.signal(signal.SIGUSR1, self.handle_usr1)
+        # Don't let SIGUSR1 disturb active requests by interrupting system calls
+        signal.siginterrupt(signal.SIGUSR1, False)
+
+    def _install_sigquit_handler(self) -> None:
+        """Install a SIGQUIT handler on workers.
+
+        - https://github.com/encode/uvicorn/issues/1116
+        - https://github.com/benoitc/gunicorn/issues/2604
+        """
+
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGQUIT, self.handle_exit, signal.SIGQUIT, None)
+
+    async def _serve(self) -> None:
+        self.config.app = self.wsgi
+        server = Server(config=self.config)
+        self._install_sigquit_handler()
+        await server.serve(sockets=self.sockets)
+        if not server.started:
+            sys.exit(Arbiter.WORKER_BOOT_ERROR)
+
+    def run(self) -> None:
+        return run(self._serve())
+
+    async def callback_notify(self) -> None:  # pragma: no cover
+        self.notify()


### PR DESCRIPTION
# Summary

Previously, `Mutliprocess` was used directly on Uvicorn to effectively manage different processes. Instead, for production purposes, gunicorn is being used as it is more stable, and workers can be added to bridge the gap between ASGI and WSGI.

This PR adds full support and migrates to using gunicorn for production, while Docker-based versions still use one uvicorn worker per container.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
