### PR TITLE
Ensure `ruff format` exits on non-zero errors for compatibility with Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,4 +7,4 @@ pre-commit:
     ruff-fmt:
       glob: "*.py"
       stage_fixed: true
-      run: ruff format {staged_files}
+      run: ruff format --exit-non-zero-on-format {staged_files}


### PR DESCRIPTION
# Summary

In order to avoid having formatted files not committed, we need to enable this option. This way, if ruff formats it, it will exit out of Lefthook; ensuring that all formatted files must be committed only.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
