### PR TITLE
Drop support for Python 3.9 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [3.9, '3.10', '3.11', '3.12', '3.13']
+        version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout Repository  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        version: ['3.10', '3.11', '3.12', '3.13']
 
     env:
       TESTCONTAINER_DOCKER_NETWORK: kanae-testcontainers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kanae"
 version = "0.1.0"
 description = "Internal backend server for ACM @ UC Merced"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.10,<4.0"
 
 [tool.pyright]
 include = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = lint, py{39,310,311,312,313}
+env_list = lint, py{310,311,312,313}
 no_package=true
 
 [testenv]


### PR DESCRIPTION
# Summary

This is mainly to address dependency issues found in #59, but also aims to move on from 3.9 to adapt the specifications found in [SPEC 0](https://scientific-python.org/specs/spec-0000/). Namely, the new adapted policy requires:

> Support for Python versions be dropped 3 years after their initial release.

[Python 3.9.13](https://peps.python.org/pep-0596/#bugfix-releases) was last released 2022/05/07, making it the last officially supported version (that is not under security support), and the last supported version will be released on [October 2025](https://peps.python.org/pep-0596/#lifespan). Thus, with ending support in 3 months, it would be advisable to adopt this policy to:

1. Be on the same Python support cycle as most dependencies
2. To aid with prevention of dependency conflicts
3. Standardize and enforce utilization of supported Python versions 

> [!CAUTION]
> If you still use Python 3.9, please upgrade to a newer supported version of Python

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
