### PR TITLE
Implement Prometheus exporter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eof=lf

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -26,14 +26,6 @@ kanae:
     # Whether the Prometheus exporter is enabled or not
     enabled: False
 
-    # The host that the Prometheus exporter will bind to. By default,
-    # it will always be set to 127.0.0.1
-    host: "127.0.0.1"
-
-    # The port used for the Prometheus exporter. By default,
-    # it will always be set to 9555
-    port: 9555
-
   # Settings for Kanae's custom rate limiters
   limiter:
 

--- a/deploy/launcher.sh
+++ b/deploy/launcher.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# We have to do this as when using gunicorn
+# Prometheus client libraries do a weird hack to put the multiproc in a folder instead
+# Thus, it is recommended to make and set the temp directory within an startup script
+# See: https://prometheus.github.io/client_python/multiprocess/
+PROMETHEUS_MULTIPROC_DIR=$(mktemp --directory) python3 -m gunicorn

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,6 @@ ENV PATH="${PATH}:/home/kanae/.local/bin"
 RUN pip install --user -r requirements.txt
 
 EXPOSE 8000
-EXPOSE 9555
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,8 +1,14 @@
 import os
 
+from prometheus_client import multiprocess
+
 bind = ["127.0.0.1:8000", "unix:/tmp/gunicorn.sock"]
 chdir = "server"
 workers = os.cpu_count() or 1
 worker_class = "utils.uvicorn.workers.KanaeWorker"
 
 wsgi_app = "launcher:app"
+
+
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -10,5 +10,5 @@ worker_class = "utils.uvicorn.workers.KanaeWorker"
 wsgi_app = "launcher:app"
 
 
-def child_exit(server, worker):
-    multiprocess.mark_process_dead(worker.pid)
+def worker_exit(server, worker):
+    multiprocess.mark_process_dead(pid=worker.pid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pybase62>=1.0.0,<2
 email-validator>=2.2.0,<3
 PyYAML>=6.0.2,<7
 gunicorn>=23.0.0,<24
+prometheus-fastapi-instrumentator>=7.1.0,<8
+prometheus-async[aiohttp]>=25.1.0,<26

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ email-validator>=2.2.0,<3
 PyYAML>=6.0.2,<7
 gunicorn>=23.0.0,<24
 prometheus-fastapi-instrumentator>=7.1.0,<8
-prometheus-async[aiohttp]>=25.1.0,<26

--- a/server/core.py
+++ b/server/core.py
@@ -34,7 +34,7 @@ from supertokens_python.recipe import (
 )
 from supertokens_python.recipe.session.interfaces import SessionContainer
 from supertokens_python.types.base import AccountInfoInput
-from utils.prometheus import PrometheusInstrumentator
+from utils.prometheus import InstrumentatorSettings, PrometheusInstrumentator
 
 # isort: off
 # isort is turned off here to clarify the different imports of interfaces and providers
@@ -194,7 +194,11 @@ class Kanae(FastAPI):
 
         self.is_prometheus_enabled: bool = config["kanae"]["prometheus"]["enabled"]
 
-        self.instrumentator = PrometheusInstrumentator(self, metric_namespace="kanae")
+        _instrumentator_settings = InstrumentatorSettings(metric_namespace="kanae")
+        self.instrumentator = PrometheusInstrumentator(
+            self, settings=_instrumentator_settings
+        )
+
         self.ph = PasswordHasher()
         self.add_exception_handler(
             HTTPException,

--- a/server/core.py
+++ b/server/core.py
@@ -191,6 +191,9 @@ class Kanae(FastAPI):
             mode="asgi",
         )
         self.config = config
+
+        self.is_prometheus_enabled: bool = config["kanae"]["prometheus"]["enabled"]
+
         self.instrumentator = PrometheusInstrumentator(self, metric_namespace="kanae")
         self.ph = PasswordHasher()
         self.add_exception_handler(
@@ -216,7 +219,7 @@ class Kanae(FastAPI):
 
         self._logger = logging.getLogger("kanae.core")
 
-        if config["kanae"]["prometheus"]["enabled"]:
+        if self.is_prometheus_enabled:
             _host = self.config["kanae"]["host"]
             _port = self.config["kanae"]["port"]
 

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -25,7 +25,7 @@ app.add_middleware(
 add_pagination(app)
 app.state.limiter = router.limiter
 
-if config["kanae"]["prometheus"]["enabled"]:
+if app.is_prometheus_enabled:
     app.instrumentator.add_middleware()
 
 

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -13,7 +13,6 @@ config_path = Path(__file__).parent / "config.yml"
 config = KanaeConfig(config_path)
 
 app = Kanae(config=config)
-app.instrumentator.add_middleware()
 app.add_middleware(get_middleware())
 app.include_router(router)
 app.add_middleware(
@@ -25,6 +24,9 @@ app.add_middleware(
 )
 add_pagination(app)
 app.state.limiter = router.limiter
+
+if config["kanae"]["prometheus"]["enabled"]:
+    app.instrumentator.add_middleware()
 
 
 if __name__ == "__main__":

--- a/server/launcher.py
+++ b/server/launcher.py
@@ -13,6 +13,7 @@ config_path = Path(__file__).parent / "config.yml"
 config = KanaeConfig(config_path)
 
 app = Kanae(config=config)
+app.instrumentator.add_middleware()
 app.add_middleware(get_middleware())
 app.include_router(router)
 app.add_middleware(

--- a/server/utils/limiter/middleware.py
+++ b/server/utils/limiter/middleware.py
@@ -11,10 +11,10 @@ from starlette.middleware.base import (
     RequestResponseEndpoint,
 )
 from starlette.routing import BaseRoute, Match
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 if TYPE_CHECKING:
     from core import Kanae
+    from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from .extension import KanaeLimiter, rate_limit_exceeded_handler
 

--- a/server/utils/prometheus.py
+++ b/server/utils/prometheus.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import asyncio
+import gzip
+import os
+import re
+from http import HTTPStatus
+from timeit import default_timer
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from fastapi.requests import Request
+from fastapi.responses import Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    CollectorRegistry,
+    Gauge,
+    generate_latest,
+    multiprocess,
+)
+from prometheus_fastapi_instrumentator import metrics, routing
+from starlette.datastructures import Headers
+from starlette.types import Message, Receive, Scope, Send
+
+if TYPE_CHECKING:
+    from core import Kanae
+
+
+class PrometheusMiddleware:
+    def __init__(
+        self,
+        app: Kanae,
+        *,
+        should_group_status_codes: bool = True,
+        should_ignore_not_templated: bool = False,
+        should_group_not_templated: bool = True,
+        should_round_latency_decimals: bool = False,
+        should_respect_env_var: bool = False,
+        should_instrument_requests_in_progress: bool = False,
+        should_exclude_streaming_duration: bool = False,
+        excluded_handlers: Sequence[Union[re.Pattern[str], str]] = (),
+        body_handlers: Sequence[Union[re.Pattern[str], str]] = (),
+        round_latency_decimals: int = 4,
+        in_progress_name: str = "http_requests_in_progress",
+        in_progress_labels: bool = False,
+        instrumentations: Sequence[Callable[[metrics.Info], None]] = (),
+        async_instrumentations: Sequence[
+            Callable[[metrics.Info], Awaitable[None]]
+        ] = (),
+        metric_namespace: str = "",
+        metric_subsystem: str = "",
+        should_only_respect_2xx_for_higher: bool = False,
+        latency_higher_buckets: Sequence[Union[float, str]] = (
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1,
+            1.5,
+            2,
+            2.5,
+            3,
+            3.5,
+            4,
+            4.5,
+            5,
+            7.5,
+            10,
+            30,
+            60,
+        ),
+        latency_lower_buckets: Sequence[Union[float, str]] = (0.1, 0.5, 1),
+        registry: CollectorRegistry = REGISTRY,
+        custom_labels: dict = {},
+    ) -> None:
+        self.app = app
+
+        self.should_group_status_codes = should_group_status_codes
+        self.should_ignore_not_templated = should_ignore_not_templated
+        self.should_group_not_templated = should_group_not_templated
+        self.should_round_latency_decimals = should_round_latency_decimals
+        self.should_respect_env_var = should_respect_env_var
+        self.should_instrument_requests_in_progress = (
+            should_instrument_requests_in_progress
+        )
+
+        self.round_latency_decimals = round_latency_decimals
+        self.in_progress_name = in_progress_name
+        self.in_progress_labels = in_progress_labels
+        self.registry = registry
+        self.custom_labels = custom_labels
+
+        self.excluded_handlers = [re.compile(path) for path in excluded_handlers]
+        self.body_handlers = [re.compile(path) for path in body_handlers]
+
+        if instrumentations:
+            self.instrumentations = instrumentations
+        else:
+            default_instrumentation = metrics.default(
+                metric_namespace=metric_namespace,
+                metric_subsystem=metric_subsystem,
+                should_only_respect_2xx_for_highr=should_only_respect_2xx_for_higher,
+                should_exclude_streaming_duration=should_exclude_streaming_duration,
+                latency_highr_buckets=latency_higher_buckets,
+                latency_lowr_buckets=latency_lower_buckets,
+                registry=self.registry,
+                custom_labels=custom_labels,
+            )
+            if default_instrumentation:
+                self.instrumentations = [default_instrumentation]
+            else:
+                self.instrumentations = []
+
+        self.async_instrumentations = async_instrumentations
+
+        self.in_progress: Optional[Gauge] = None
+        if self.should_instrument_requests_in_progress:
+            labels = (
+                (
+                    "method",
+                    "handler",
+                )
+                if self.in_progress_labels
+                else ()
+            )
+            self.in_progress = Gauge(
+                name=self.in_progress_name,
+                documentation="Number of HTTP requests in progress.",
+                labelnames=labels,
+                multiprocess_mode="livesum",
+            )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        request = Request(scope)
+        start_time = default_timer()
+
+        handler, is_templated = self._get_handler(request)
+        is_excluded = self._is_handler_excluded(handler, is_templated)
+        handler = (
+            "none" if not is_templated and self.should_group_not_templated else handler
+        )
+
+        if not is_excluded and self.in_progress:
+            if self.in_progress_labels:
+                in_progress = self.in_progress.labels(request.method, handler)
+            else:
+                in_progress = self.in_progress
+            in_progress.inc()
+
+        status_code = 500
+        headers = []
+        body = b""
+        response_start_time = None
+
+        # Message body collected for handlers matching body_handlers patterns.
+        if any(pattern.search(handler) for pattern in self.body_handlers):
+
+            async def send_wrapper(message: Message) -> None:
+                if message["type"] == "http.response.start":
+                    nonlocal status_code, headers, response_start_time
+                    headers = message["headers"]
+                    status_code = message["status"]
+                    response_start_time = default_timer()
+                elif message["type"] == "http.response.body" and message["body"]:
+                    nonlocal body
+                    body += message["body"]
+                await send(message)
+
+        else:
+
+            async def send_wrapper(message: Message) -> None:
+                if message["type"] == "http.response.start":
+                    nonlocal status_code, headers, response_start_time
+                    headers = message["headers"]
+                    status_code = message["status"]
+                    response_start_time = default_timer()
+                await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception as exc:
+            raise exc
+        finally:
+            status = (
+                str(status_code.value)
+                if isinstance(status_code, HTTPStatus)
+                else str(status_code)
+            )
+
+            if not is_excluded:
+                duration = max(default_timer() - start_time, 0.0)
+                duration_without_streaming = 0.0
+
+                if response_start_time:
+                    duration_without_streaming = max(
+                        response_start_time - start_time, 0.0
+                    )
+
+                if self.should_instrument_requests_in_progress:
+                    in_progress.dec()  # type: ignore
+
+                if self.should_round_latency_decimals:
+                    duration = round(duration, self.round_latency_decimals)
+                    duration_without_streaming = round(
+                        duration_without_streaming, self.round_latency_decimals
+                    )
+
+                if self.should_group_status_codes:
+                    status = status[0] + "xx"
+
+                response = Response(
+                    content=body, headers=Headers(raw=headers), status_code=status_code
+                )
+
+                info = metrics.Info(
+                    request=request,
+                    response=response,
+                    method=request.method,
+                    modified_handler=handler,
+                    modified_status=status,
+                    modified_duration=duration,
+                    modified_duration_without_streaming=duration_without_streaming,
+                )
+
+                for instrumentation in self.instrumentations:
+                    instrumentation(info)
+
+                await asyncio.gather(
+                    *[
+                        instrumentation(info)
+                        for instrumentation in self.async_instrumentations
+                    ]
+                )
+
+    def _get_handler(self, request: Request) -> Tuple[str, bool]:
+        """Extracts either template or (if no template) path.
+
+        Args:
+            request (Request): Python Requests request object.
+
+        Returns:
+            Tuple[str, bool]: Tuple with two elements. First element is either
+                template or if no template the path. Second element tells you
+                if the path is templated or not.
+        """
+        route_name = routing.get_route_name(request)
+        return route_name or request.url.path, True if route_name else False
+
+    def _is_handler_excluded(self, handler: str, is_templated: bool) -> bool:
+        """Determines if the handler should be ignored.
+
+        Args:
+            handler (str): Handler that handles the request.
+            is_templated (bool): Shows if the request is templated.
+
+        Returns:
+            bool: `True` if excluded, `False` if not.
+        """
+
+        if not is_templated and self.should_ignore_not_templated:
+            return True
+
+        if any(pattern.search(handler) for pattern in self.excluded_handlers):
+            return True
+
+        return False
+
+
+class PrometheusInstrumentator:
+    def __init__(
+        self,
+        app: Kanae,
+        *,
+        should_group_status_codes: bool = True,
+        should_ignore_not_templated: bool = False,
+        should_group_not_templated: bool = True,
+        should_round_latency_decimals: bool = False,
+        should_instrument_requests_in_progress: bool = False,
+        should_exclude_streaming_duration: bool = False,
+        excluded_handlers: List[str] = [],
+        body_handlers: List[str] = [],
+        round_latency_decimals: int = 4,
+        in_progress_name: str = "http_requests_in_progress",
+        in_progress_labels: bool = False,
+        metric_namespace: str = "",
+        metric_subsystem: str = "",
+        registry: Union[CollectorRegistry, None] = None,
+    ) -> None:
+        self.app = app
+
+        self.should_group_status_codes = should_group_status_codes
+        self.should_ignore_not_templated = should_ignore_not_templated
+        self.should_group_not_templated = should_group_not_templated
+        self.should_round_latency_decimals = should_round_latency_decimals
+        self.should_instrument_requests_in_progress = (
+            should_instrument_requests_in_progress
+        )
+        self.should_exclude_streaming_duration = should_exclude_streaming_duration
+
+        self.round_latency_decimals = round_latency_decimals
+        self.in_progress_name = in_progress_name
+        self.in_progress_labels = in_progress_labels
+        self.metric_namespace = metric_namespace
+        self.metric_subsystem = metric_subsystem
+
+        self.excluded_handlers = [re.compile(path) for path in excluded_handlers]
+        self.body_handlers = [re.compile(path) for path in body_handlers]
+
+        self.instrumentations: List[Callable[[metrics.Info], None]] = []
+        self.async_instrumentations: List[
+            Callable[[metrics.Info], Awaitable[None]]
+        ] = []
+
+        if registry:
+            self.registry = registry
+        else:
+            self.registry = REGISTRY
+
+        # Very hacky way to check whether we are using gunicorn or not
+        # TODO: fix this
+        server_software = os.environ.get("SERVER_SOFTWARE")
+        if server_software and "gunicorn" in server_software:
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = ""
+
+    def add_middleware(
+        self,
+        should_only_respect_2xx_for_higher: bool = False,
+        latency_higher_buckets: Sequence[Union[float, str]] = (
+            0.01,
+            0.025,
+            0.05,
+            0.075,
+            0.1,
+            0.25,
+            0.5,
+            0.75,
+            1,
+            1.5,
+            2,
+            2.5,
+            3,
+            3.5,
+            4,
+            4.5,
+            5,
+            7.5,
+            10,
+            30,
+            60,
+        ),
+        latency_lower_buckets: Sequence[Union[float, str]] = (0.1, 0.5, 1),
+    ) -> None:
+        self.app.add_middleware(
+            PrometheusMiddleware,  # type: ignore (This is actually correct)
+            should_group_status_codes=self.should_group_status_codes,
+            should_ignore_not_templated=self.should_ignore_not_templated,
+            should_group_not_templated=self.should_group_not_templated,
+            should_round_latency_decimals=self.should_round_latency_decimals,
+            should_instrument_requests_in_progress=self.should_instrument_requests_in_progress,
+            should_exclude_streaming_duration=self.should_exclude_streaming_duration,
+            round_latency_decimals=self.round_latency_decimals,
+            in_progress_name=self.in_progress_name,
+            in_progress_labels=self.in_progress_labels,
+            instrumentations=self.instrumentations,
+            async_instrumentations=self.async_instrumentations,
+            excluded_handlers=self.excluded_handlers,
+            body_handlers=self.body_handlers,
+            metric_namespace=self.metric_namespace,
+            metric_subsystem=self.metric_subsystem,
+            should_only_respect_2xx_for_higher=should_only_respect_2xx_for_higher,
+            latency_higher_buckets=latency_higher_buckets,
+            latency_lower_buckets=latency_lower_buckets,
+            registry=self.registry,
+        )
+
+    def start(
+        self,
+        should_gzip: bool = False,
+        endpoint: str = "/metrics",
+        include_in_schema: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        def metrics(request: Request) -> Response:
+            """Endpoint that serves Prometheus metrics."""
+
+            ephemeral_registry = self.registry
+            if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+                ephemeral_registry = CollectorRegistry()
+                multiprocess.MultiProcessCollector(ephemeral_registry)
+
+            if should_gzip and "gzip" in request.headers.get("Accept-Encoding", ""):
+                resp = Response(
+                    content=gzip.compress(generate_latest(ephemeral_registry))
+                )
+                resp.headers["Content-Type"] = CONTENT_TYPE_LATEST
+                resp.headers["Content-Encoding"] = "gzip"
+            else:
+                resp = Response(content=generate_latest(ephemeral_registry))
+                resp.headers["Content-Type"] = CONTENT_TYPE_LATEST
+
+            return resp
+
+        self.app.add_route(
+            path=endpoint, route=metrics, include_in_schema=include_in_schema, **kwargs
+        )

--- a/server/utils/prometheus.py
+++ b/server/utils/prometheus.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import time
 from http import HTTPStatus
-from timeit import default_timer
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -148,7 +148,7 @@ class PrometheusMiddleware:
             return await self.app(scope, receive, send)
 
         request = Request(scope)
-        start_time = default_timer()
+        start_time = time.perf_counter()
 
         handler, is_templated = self._get_handler(request)
         is_excluded = self._is_handler_excluded(handler, is_templated)
@@ -176,7 +176,7 @@ class PrometheusMiddleware:
                     nonlocal status_code, headers, response_start_time
                     headers = message["headers"]
                     status_code = message["status"]
-                    response_start_time = default_timer()
+                    response_start_time = time.perf_counter()
                 elif message["type"] == "http.response.body" and message["body"]:
                     nonlocal body
                     body += message["body"]
@@ -189,7 +189,7 @@ class PrometheusMiddleware:
                     nonlocal status_code, headers, response_start_time
                     headers = message["headers"]
                     status_code = message["status"]
-                    response_start_time = default_timer()
+                    response_start_time = time.perf_counter()
                 await send(message)
 
         try:
@@ -204,7 +204,7 @@ class PrometheusMiddleware:
             )
 
             if not is_excluded:
-                duration = max(default_timer() - start_time, 0.0)
+                duration = max(time.perf_counter() - start_time, 0.0)
                 duration_without_streaming = 0.0
 
                 if response_start_time:

--- a/server/utils/prometheus.py
+++ b/server/utils/prometheus.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 import re
 import time
-from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -197,11 +196,7 @@ class PrometheusMiddleware:
         except Exception as exc:
             raise exc
         finally:
-            status = (
-                str(status_code.value)
-                if isinstance(status_code, HTTPStatus)
-                else str(status_code)
-            )
+            status = str(status_code)
 
             if not is_excluded:
                 duration = max(time.perf_counter() - start_time, 0.0)

--- a/server/utils/prometheus.py
+++ b/server/utils/prometheus.py
@@ -162,10 +162,11 @@ class PrometheusMiddleware:
         )
 
         if not is_excluded and self.in_progress:
-            if self.in_progress_labels:
-                in_progress = self.in_progress.labels(request.method, handler)
-            else:
-                in_progress = self.in_progress
+            in_progress = (
+                self.in_progress.labels(request.method, handler)
+                if self.in_progress_labels
+                else self.in_progress
+            )
             in_progress.inc()
 
         status_code = 500
@@ -222,8 +223,7 @@ class PrometheusMiddleware:
                         duration_without_streaming, self.round_latency_decimals
                     )
 
-                if self.should_group_status_codes:
-                    status = status[0] + "xx"
+                status = status[0] + "xx" if self.should_group_status_codes else status
 
                 response = Response(
                     content=body, headers=Headers(raw=headers), status_code=status_code


### PR DESCRIPTION
# Summary

Implements Prometheus metrics through `prometheus-fastapi-instrumentator`. This is the final general feature for Kanae, as 
it was asked for me to implement metrics for data collection. This PR only adds basic HTTP metrics, such as response size and the amount of requests made. This does not include metrics directly from Kanae; only the default HTTP metrics. This PR fully completes all general features for Kanae, as this feature was asked by previous leadership to implement.

There are some notable changes compared to previous versions in this PR. Namely:

- Metrics are exposed on the same server as all operations. Thus, the endpoint becomes `127.0.0.1:8000/metrics`, not `127.0.0.1:9555/metrics` as envisioned
- Added `deploy/launcher.sh` in order to reliably allow the Prometheus client library to manage multiprocess collection
- Ensure that all `.sh` files have their EOL set to LF instead of automatically choosing

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
