### PR TITLE
Increase Uvicorn workers to 2

### DIFF
--- a/server/launcher.py
+++ b/server/launcher.py
@@ -34,6 +34,7 @@ if __name__ == "__main__":
         "launcher:app",
         port=config["kanae"]["port"],
         host=config["kanae"]["host"],
+        workers=2,
         access_log=True,
     )
 


### PR DESCRIPTION
# Summary

The rationale is that one worker is not enough to handle everything, so having 2 workers per instance is a good stragety. The second worker is really only used to handle other requests, thus freeing up the resources needed for the first worker.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
