### PR TITLE
Force Gunicorn to use UNIX socket from `/run/`

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,7 +2,7 @@ import os
 
 from prometheus_client import multiprocess
 
-bind = ["127.0.0.1:8000", "unix:/tmp/gunicorn.sock"]
+bind = ["127.0.0.1:8000", "unix:/run/kanae/gunicorn.sock"]
 chdir = "server"
 workers = os.cpu_count() or 1
 worker_class = "utils.uvicorn.workers.KanaeWorker"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,7 +2,7 @@ import os
 
 from prometheus_client import multiprocess
 
-bind = ["127.0.0.1:8000", "unix:/run/kanae/gunicorn.sock"]
+bind = ["127.0.0.1:8000", "unix:/run/kanae.sock"]
 chdir = "server"
 workers = os.cpu_count() or 1
 worker_class = "utils.uvicorn.workers.KanaeWorker"


### PR DESCRIPTION
# Summary

Ensures that we have the unix socket running at the right place in prod.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
