### PR TITLE
Normalize existing docstrings within `server.utils`

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -20,10 +20,10 @@ from testcontainers.core.utils import raise_for_deprecated_parameter
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
 from testcontainers.postgres import PostgresContainer
 from utils.config import KanaeConfig
+from utils.limiter import get_remote_address
 from utils.limiter.extension import (
     KanaeLimiter,
     RateLimitExceeded,
-    get_remote_address,
     rate_limit_exceeded_handler,
 )
 from utils.limiter.middleware import LimiterASGIMiddleware, LimiterMiddleware

--- a/server/tests/test_limiter.py
+++ b/server/tests/test_limiter.py
@@ -3,7 +3,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
-from utils.limiter.extension import get_ipaddr
+from utils.limiter import get_ipaddr
 from yarl import URL
 
 

--- a/server/utils/limiter/__init__.py
+++ b/server/utils/limiter/__init__.py
@@ -1,3 +1,7 @@
 """Internal package that rewrites Slowapi to be entirely async"""
 
 from .extension import KanaeLimiter as KanaeLimiter
+from .utils import (
+    get_ipaddr as get_ipaddr,
+    get_remote_address as get_remote_address,
+)

--- a/server/utils/limiter/extension.py
+++ b/server/utils/limiter/extension.py
@@ -42,9 +42,14 @@ StrOrCallableStr = Union[str, Callable[..., str]]
 async def rate_limit_exceeded_handler(
     request: Request, exc: "RateLimitExceeded"
 ) -> Response:
-    """
-    Build a simple JSON response that includes the details of the rate limit
-    that was hit. If no limit is hit, the countdown is added to headers.
+    """Builds a JSON response that includes the details of the rate limit that was hit.
+
+    Args:
+        request (Request): Instance of `Request`
+        exc (RateLimitExceeded): Instance of the exception `RateLimitExceeded`
+
+    Returns:
+        Response: A generic JSON response that includes rate limit headers
     """
     response = ORJSONResponse(
         {"error": f"Rate limit exceeded: {exc.detail}"}, status_code=429
@@ -56,8 +61,10 @@ async def rate_limit_exceeded_handler(
 
 
 class RateLimitExceeded(HTTPException):
-    """
-    exception raised when a rate limit is hit.
+    """Exception for when an rate limit has been hit
+
+    Args:
+        limit (LimitItem): Instance of `LimitItem`
     """
 
     limit = None

--- a/server/utils/limiter/middleware.py
+++ b/server/utils/limiter/middleware.py
@@ -52,7 +52,7 @@ def _should_exempt(limiter: KanaeLimiter, handler: Optional[Callable]) -> bool:
     return False
 
 
-async def check_limits(
+async def _check_limits(
     limiter: KanaeLimiter, request: Request, handler: Optional[Callable], app: Kanae
 ) -> tuple[Optional[Response], bool]:
     if limiter._auto_check and not getattr(
@@ -86,7 +86,7 @@ class LimiterMiddleware(BaseHTTPMiddleware):
         if _should_exempt(limiter, handler):
             return await call_next(request)
 
-        error_response, should_inject_headers = await check_limits(
+        error_response, should_inject_headers = await _check_limits(
             limiter, request, handler, app
         )
         if error_response:
@@ -155,7 +155,7 @@ class _ASGIMiddlewareResponder:
         if _should_exempt(limiter, handler):
             return await self.app(scope, receive, self.send)
 
-        error_response, should_inject_headers = await check_limits(
+        error_response, should_inject_headers = await _check_limits(
             limiter, request, handler, _app
         )
         if error_response:

--- a/server/utils/limiter/middleware.py
+++ b/server/utils/limiter/middleware.py
@@ -55,11 +55,6 @@ def _should_exempt(limiter: KanaeLimiter, handler: Optional[Callable]) -> bool:
 async def check_limits(
     limiter: KanaeLimiter, request: Request, handler: Optional[Callable], app: Kanae
 ) -> tuple[Optional[Response], bool]:
-    """
-    Returns a `Response` object if an error occurred, as well as a boolean to know
-    whether we should inject headers or not.
-    Used in our ASGI middleware, this support both synchronous or asynchronous exception handlers.
-    """
     if limiter._auto_check and not getattr(
         request.state, "_rate_limiting_complete", False
     ):

--- a/server/utils/limiter/utils.py
+++ b/server/utils/limiter/utils.py
@@ -2,11 +2,13 @@ from fastapi import Request
 
 
 def get_ipaddr(request: Request) -> str:
-    """
-    Returns the ip address for the current request (or 127.0.0.1 if none found)
-     based on the X-Forwarded-For headers.
-     Note that a more robust method for determining IP address of the client is
-     provided by uvicorn's ProxyHeadersMiddleware.
+    """Returns the IP address for the current request through the `X-Forwarded-For` headers
+
+    Args:
+        request (Request): Instance of `Request`
+
+    Returns:
+        str: IP Address from the request
     """
     if "X_FORWARDED_FOR" in request.headers:
         return request.headers["X_FORWARDED_FOR"]
@@ -18,8 +20,13 @@ def get_ipaddr(request: Request) -> str:
 
 
 def get_remote_address(request: Request) -> str:
-    """
-    Returns the ip address for the current request (or 127.0.0.1 if none found)
+    """Returns the IP address through the currently provided request
+
+    Args:
+        request: (Request): Instance of `Request`
+
+    Returns:
+        str: IP Address from the request
     """
     if not request.client or not request.client.host:
         return "127.0.0.1"

--- a/server/utils/request.py
+++ b/server/utils/request.py
@@ -14,4 +14,9 @@ class RouteRequest(Request):
 
     @property
     def app(self) -> Kanae:
+        """Returns the instance of our app, which is `Kanae`
+
+        Returns:
+            Kanae: Application instance
+        """
         return self.scope["app"]

--- a/server/utils/router.py
+++ b/server/utils/router.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from fastapi import APIRouter
 from utils.limiter import KanaeLimiter
-from utils.limiter.extension import get_remote_address
+from utils.limiter.utils import get_remote_address
 
 from .config import KanaeConfig
 


### PR DESCRIPTION
# Summary

The purpose of this is to normalize all of the docstrings that were pulled from existing utils that were copied over from other projects to be in Google's docstring format. This way, the docstrings are consistent throughout the codebase.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
