### PR TITLE
Utilize uv in Docker and workflows

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,14 +32,21 @@ FROM python:3.13-slim-trixie
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/kanae
 
+# Set up non-root user
+RUN groupadd --system --gid 999 kanae \
+ && useradd --system --gid 999 --uid 999 --no-create-home kanae
+
 # Copy the server from the builder
-COPY --from=build --chown=kanae:kanae /kanae /kanae
-COPY --from=build --chmod=+x /tini /tini
+COPY --from=build --chown=kanae:kanae --chmod=755 /kanae /kanae
+COPY --from=build --chown=kanae:kanae --chmod=+x /tini /tini
 
 WORKDIR /kanae/
 
 # Place executables in the environment at the front of the path
 ENV PATH="/kanae/.venv/bin:$PATH"
+
+# Use non-root user
+USER kanae
 
 EXPOSE 8000
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd --system --gid 999 kanae \
  && useradd --system --gid 999 --uid 999 --no-create-home kanae
 
 # Copy the server from the builder
-COPY --from=build --chown=kanae:kanae --chmod=755 /kanae /kanae
+COPY --from=build --chmod=755 /kanae /kanae
 COPY --from=build --chmod=+x /tini /tini
 
 WORKDIR /kanae/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN groupadd --system --gid 999 kanae \
 
 # Copy the server from the builder
 COPY --from=build --chown=kanae:kanae --chmod=755 /kanae /kanae
-COPY --from=build --chown=kanae:kanae --chmod=+x /tini /tini
+COPY --from=build --chmod=+x /tini /tini
 
 WORKDIR /kanae/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,51 @@
-FROM python:3.13-slim-trixie
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim AS build
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Compile bytecode and enable caching
+# Ref: https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
+# Ref: https://docs.astral.sh/uv/guides/integration/docker/#caching
+ENV UV_COMPILE_BYTECODE=1 
+ENV UV_LINK_MODE=copy
+
+# Disable Python downloads as the system Python interpreter instead
+ENV UV_PYTHON_DOWNLOADS=0
+
+# Set Tini version
+# Ref: https://github.com/krallin/tini?tab=readme-ov-file#using-tini
 ENV TINI_VERSION=v0.19.0
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
 
-WORKDIR /kanae
-COPY /server /kanae/server/
-COPY /requirements.txt /kanae/requirements.txt
+WORKDIR /server/
 
-RUN adduser --disabled-password --gecos "" kanae \
-  && chown -R kanae:kanae /kanae
+COPY requirements.txt /server/
 
-USER kanae
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=requirements.txt,target=requirements.txt \
+    uv venv && uv pip install -r requirements.txt
 
-ENV PATH="${PATH}:/home/kanae/.local/bin"
+# Add project source code
+COPY server /server
 
-RUN pip install --user -r requirements.txt
+FROM python:3.13-slim-trixie
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/server
+
+# Copy the server from the builder
+COPY --from=build --chown=server:server /server /server
+COPY --from=build --chmod=+x /tini /tini
+
+WORKDIR /server/
+
+# Place executables in the environment at the front of the path
+ENV PATH="/server/.venv/bin:$PATH"
 
 EXPOSE 8000
 
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["python3", "/kanae/server/launcher.py"]
+CMD ["python3", "/server/launcher.py"]
 
 STOPSIGNAL SIGTERM
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@ ENV TINI_VERSION=v0.19.0
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 
-WORKDIR /server/
+WORKDIR /kanae/
 
-COPY requirements.txt /server/
+COPY requirements.txt /kanae
 
 # Install dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -25,27 +25,27 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv venv && uv pip install -r requirements.txt
 
 # Add project source code
-COPY server /server
+COPY server /kanae
 
 FROM python:3.13-slim-trixie
 
 ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/server
+ENV PYTHONPATH=/kanae
 
 # Copy the server from the builder
-COPY --from=build --chown=server:server /server /server
+COPY --from=build --chown=kanae:kanae /kanae /kanae
 COPY --from=build --chmod=+x /tini /tini
 
-WORKDIR /server/
+WORKDIR /kanae/
 
 # Place executables in the environment at the front of the path
-ENV PATH="/server/.venv/bin:$PATH"
+ENV PATH="/kanae/.venv/bin:$PATH"
 
 EXPOSE 8000
 
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["python3", "/server/launcher.py"]
+CMD ["python3", "/kanae/launcher.py"]
 
 STOPSIGNAL SIGTERM
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -4,17 +4,13 @@ name: kanae_dev
 services:
   database:
     container_name: kanae_postgres
-    build:
-      context: ../
-      dockerfile: docker/pg-test/Dockerfile
+    image: postgres:17
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE_NAME}
       POSTGRES_USER: ${DB_USERNAME}
     volumes:
       - database:/var/lib/postgresql/data
-    env_file:
-      - .env
     ports:
       - 5432:5432
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -6,9 +6,12 @@ services:
     image: ghcr.io/ucmercedacm/kanae:latest
     volumes:
       # Do not edit the next line. If you want to change the path of the configuration file, please edit the CONFIG_LOCATION variable
-      - ${CONFIG_LOCATION}:/kanae/server/config.yml
+      - ${CONFIG_LOCATION}:/kanae/config.yml
     ports:
       - 8000:8000
+    networks:
+      - default
+      - db_bridge
     depends_on:
       database:
         condition: service_healthy
@@ -16,15 +19,13 @@ services:
       valkey:
         condition: service_healthy
         restart: true
-    env_file:
-      - .env
+      migrate:
+        condition: service_completed_successfully
     restart: always
 
   database:
     container_name: kanae_postgres
-    build:
-      context: ../
-      dockerfile: docker/pg-test/Dockerfile
+    image: postgres:17
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE_NAME}
@@ -32,6 +33,9 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
     ports:
       - 5432:5432
+    networks:
+      - default
+      - db_bridge
     volumes:
       - database:/var/lib/postgresql/data
     healthcheck:
@@ -48,8 +52,27 @@ services:
       test: valkey-cli PING || exit 1
     ports:
       - 6379:6379
+    restart: always
 
-  kanae-prometheus:
+  migrate:
+    container_name: kanae_migrate
+    image: arigaio/atlas:latest
+    command: >
+      schema apply
+      --auto-approve
+      --to "file://schema.sql"
+      --url "postgres://${DB_USERNAME}:${DB_PASSWORD}@database:5432/${DB_DATABASE_NAME}?search_path=public&sslmode=disable"
+      --dev-url "postgres://${DB_USERNAME}:${DB_PASSWORD}@database:5432/postgres?search_path=public&sslmode=disable"
+    networks:
+      - db_bridge
+      - default
+    depends_on:
+      database:
+        condition: service_healthy
+    volumes:
+      - ../server/schema.sql:/schema.sql 
+
+  prometheus:
     container_name: kanae_prometheus
     ports:
       - 9090:9090
@@ -59,8 +82,8 @@ services:
       - prometheus-data:/prometheus
 
   # first login uses admin/admin
-  # add data source for http://kanae-prometheus:9090 to get started
-  kanae-grafana:
+  # add data source for http://prometheus:9090 to get started
+  grafana:
     container_name: kanae_grafana
     command: ['./run.sh', '-disable-reporting']
     ports:
@@ -73,3 +96,8 @@ volumes:
   database:
   prometheus-data:
   grafana-data:
+
+networks:
+  db_bridge:
+    driver: bridge
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,9 +6,12 @@ services:
     image: ghcr.io/ucmercedacm/kanae:latest
     volumes:
       # Do not edit the next line. If you want to change the path of the configuration file, please edit the CONFIG_LOCATION variable
-      - ${CONFIG_LOCATION}:/kanae/server/config.yml
+      - ${CONFIG_LOCATION}:/kanae/config.yml
     ports:
       - 8000:8000
+    networks:
+      - default
+      - db_bridge
     depends_on:
       database:
         condition: service_healthy
@@ -16,15 +19,13 @@ services:
       valkey:
         condition: service_healthy
         restart: true
-    env_file:
-      - .env
+      migrate:
+        condition: service_completed_successfully
     restart: always
 
   database:
     container_name: kanae_postgres
-    build:
-      context: ../
-      dockerfile: docker/pg-test/Dockerfile
+    image: postgres:17
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_DATABASE_NAME}
@@ -32,6 +33,9 @@ services:
       POSTGRES_INITDB_ARGS: '--data-checksums'
     ports:
       - 5432:5432
+    networks:
+      - default
+      - db_bridge
     volumes:
       - database:/var/lib/postgresql/data
     healthcheck:
@@ -48,6 +52,29 @@ services:
       test: valkey-cli PING || exit 1
     ports:
       - 6379:6379
+    restart: always
 
+  migrate:
+    container_name: kanae_migrate
+    image: arigaio/atlas:latest
+    command: >
+      schema apply
+      --auto-approve
+      --to "file://schema.sql"
+      --url "postgres://${DB_USERNAME}:${DB_PASSWORD}@database:5432/${DB_DATABASE_NAME}?search_path=public&sslmode=disable"
+      --dev-url "postgres://${DB_USERNAME}:${DB_PASSWORD}@database:5432/postgres?search_path=public&sslmode=disable"
+    networks:
+      - db_bridge
+      - default
+    depends_on:
+      database:
+        condition: service_healthy
+    volumes:
+      - ../server/schema.sql:/schema.sql
+      
 volumes:
   database:
+
+networks:
+  db_bridge:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,10 @@ name: kanae
 services:
   kanae:
     container_name: kanae
-    image: ghcr.io/ucmercedacm/kanae:latest
+    # image: ghcr.io/ucmercedacm/kanae:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     volumes:
       # Do not edit the next line. If you want to change the path of the configuration file, please edit the CONFIG_LOCATION variable
       - ${CONFIG_LOCATION}:/kanae/config.yml

--- a/docker/pg-test/Dockerfile
+++ b/docker/pg-test/Dockerfile
@@ -1,4 +1,0 @@
-FROM postgres:17-trixie
-COPY /server/schema.sql /docker-entrypoint-initdb.d/
-
-USER postgres

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -191,17 +191,17 @@ class KanaeUvicornConfig(UvicornConfig):
         handler.setFormatter(self._determine_formatter(handler))
 
         if self.access_log:
-            file_handler = RotatingFileHandler(
-                filename="kanae-access.log",
-                encoding="utf-8",
-                mode="w",
-                maxBytes=max_bytes,
-                backupCount=5,
-            )
             access_logger.setLevel(level)
             access_logger.addHandler(handler)
 
             if not self._is_docker():
+                file_handler = RotatingFileHandler(
+                    filename="kanae-access.log",
+                    encoding="utf-8",
+                    mode="w",
+                    maxBytes=max_bytes,
+                    backupCount=5,
+                )
                 access_logger.addHandler(file_handler)
 
         root.setLevel(level)


### PR DESCRIPTION
# Summary

There are several notable modifications done to more deeply utilize [uv](<https://docs.astral.sh/uv/>) for both performance gains and tying loose ends with our workflows. These changes include:

- Utilizing uv within Dockerfiles
    - By utilizing uv, we can dramatically increase build times, in particular, with installing dependencies
    - Image sizes has also decreased, as we are now using recommended optimization techniquies by Astral (the team behind uv and ruff). A list of these optimizations can be found below:
        - [Compling bytecode](<https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode>)
        - [Cache mounts](<https://docs.astral.sh/uv/guides/integration/docker/#caching>)
        - Multi-stage builds, with the first stage builds and prepares everything, and the second copies everything over to run
            - This reduces the end result image sizes
- Replacing tox with uv
    - Traditionally, [tox](<https://tox.wiki/en/4.30.3/>) is used to automate testing within multiple Python versions, but this is rarely used in practice
        - This is due to the Github Actions workflows testing the versions already
    - By replacing tox with uv, we get the performance benefits of uv without sacrificing the automated testing within mutiple Python versions
- Applying migrations within prod and preview stacks
    - Finally figured out a way, so the docker compose stacks actually work properly
    - Effectively, once the database is ready, we run [Atlas](<https://atlasgo.io>) within another docker container to apply the migrations in one go, and then the server is ran.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
