### PR TITLE
Fix manual migrations for Atlas

### DIFF
--- a/atlas.hcl
+++ b/atlas.hcl
@@ -3,12 +3,17 @@ variable "url" {
   description = "The URL used for the database"
 }
 
+variable "dev_url" {
+  type        = string
+  description = "The database to point to that MUST have pg_trgm installed to make Atlas not complain that gin operators don't exist"
+}
+
 env "dev" {
   schema {
     src = "file://src/schema.sql"
   }
   url = var.url
-  dev = "docker://postgres/18/dev?search_path=public"
+  dev = var.dev_url
 }
 
 env "prod" {

--- a/mise.toml
+++ b/mise.toml
@@ -19,7 +19,7 @@ pin = true
 [env]
 _.file = [{ path = "{{ config_root }}/docker/.env" }]
 DATABASE_URL = "postgres://{{env.DB_USERNAME}}:{{env.DB_PASSWORD}}@localhost:5432/{{env.DB_DATABASE_NAME}}?search_path=public&sslmode=disable"
-
+DEV_DATABASE_URL = "postgres://{{env.DB_USERNAME}}:{{env.DB_PASSWORD}}@localhost:5432/postgres?search_path=public&sslmode=disable"
 
 # Docker
 [tasks."docker:preview"]
@@ -92,12 +92,12 @@ run_windows = "Test-Path {{ config_root }}/docker/.env"
 [tasks."server:schema:plan"]
 depends = ["server:check-env"]
 description = "Plans schema diffs"
-run = "atlas schema plan --to file://src/schema.sql --env dev --var url=$DATABASE_URL"
+run = "atlas schema plan --to file://src/schema.sql --env dev --var url=$DATABASE_URL --var dev_url=$DEV_DATABASE_URL"
 
 [tasks."server:schema:apply"]
 depends = ["server:check-env"]
 description = "Applies schema diffs to database"
-run = "atlas schema apply --auto-approve --env dev --var url=$DATABASE_URL"
+run = "atlas schema apply --auto-approve --env dev --var url=$DATABASE_URL --var dev_url=$DEV_DATABASE_URL"
 
 [tasks."server:docker:up"]
 depends = ["server:check-env"]


### PR DESCRIPTION
# Summary

Previously, the atlas migration depended on having `pg_trgm` installed because we need it for the trigram checks. This broke our manual flow, and although we could put it in the schema to apply, Atlas requires us to login to use this feature. So, this is the fix for it. It's also slightly faster now because Atlas doesn't spin up an ephmeral postgres container to apply the changes in.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
