### PR TITLE
Utilize sudo-based escalation across routes

### DIFF
--- a/scripts/test-flow.sh
+++ b/scripts/test-flow.sh
@@ -381,7 +381,105 @@ ok "sudo revoke idempotent"
 
 warn "sudo: positive elevate path needs a fresh AAL2 (TOTP) session — not covered by password-only smoke flow"
 
-# ── 14. logout invalidates session (best-effort) ──────────────────────────────
+# ── 14. member management — sudo-gated role write + hard delete ────────────────
+# The smoke identity is aal1 (password only) so it cannot self-elevate to sudo.
+# Promote it to Role:root via the keto side-channel (same mechanism as the role
+# grants above) so it satisfies check_any(has_role(ROOT), has_sudo()), then drive
+# the real Keto/Kratos teardown against throwaway victims.
+step "14. member management (role write + hard delete)"
+
+register_victim() {
+	# register_victim <cookie-jar> <email>; sets REGISTERED_ID on success.
+	local jar="$1" email="$2" flow csrf resp row
+	flow=$(curl -sc "$jar" -b "$jar" -H "$H_ACCEPT" \
+		"$KRATOS_PUBLIC/self-service/registration/browser" | jq -r .id)
+	csrf=$(curl -sc "$jar" -b "$jar" -H "$H_ACCEPT" \
+		"$KRATOS_PUBLIC/self-service/registration/flows?id=$flow" \
+		| jq -r '.ui.nodes[] | select(.attributes.name=="csrf_token") | .attributes.value')
+	resp=$(curl -sc "$jar" -b "$jar" -H "$H_CONTENT_TYPE" -H "$H_ACCEPT" \
+		-X POST "$KRATOS_PUBLIC/self-service/registration?flow=$flow" \
+		-d '{"method":"password","csrf_token":"'"$csrf"'","password":"'"$PASSWORD"'","traits":{"email":"'"$email"'","name":"Victim"}}')
+	REGISTERED_ID=$(jq -r '.identity.id // empty' <<<"$resp")
+	[[ -n "$REGISTERED_ID" ]] \
+		|| fail "victim registration failed: $(jq -c '.ui.messages // .' <<<"$resp")"
+	# the registration webhook syncs the members row; allow a brief retry window.
+	row=""
+	for _ in 1 2 3 4 5; do
+		row=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tA \
+			-c "SELECT 1 FROM members WHERE id = '$REGISTERED_ID';" 2>/dev/null || true)
+		[[ -n "$row" ]] && break
+		sleep 1
+	done
+	[[ -n "$row" ]] || fail "victim members row never appeared for $email"
+}
+
+# unauthenticated → 401 on both gated routes
+assert_http 401 PUT "$KANAE/members/$IDENTITY_ID/role" \
+	-H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+assert_http 401 DELETE "$KANAE/members/$IDENTITY_ID"
+
+# smoke identity is admin (not root, not sudo) → 403 on the gated route
+assert_http 403 PUT "$KANAE/members/$IDENTITY_ID/role" \
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+
+# promote smoke identity to root so it passes the member-management gate
+curl -sf -X PUT "$KETO_WRITE/admin/relation-tuples" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"namespace":"Role","object":"root","relation":"member","subject_id":"'"$IDENTITY_ID"'"}' >/dev/null
+docker exec "$VALKEY_CONTAINER" valkey-cli FLUSHDB >/dev/null
+ok "root tuple written, cache flushed"
+
+# self-guard: cannot modify or delete your own account via the admin route
+assert_http 409 PUT "$KANAE/members/$IDENTITY_ID/role" \
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+assert_http 409 DELETE "$KANAE/members/$IDENTITY_ID" -b "$COOKIES"
+
+# authorized but no such member → 404
+assert_http 404 DELETE "$KANAE/members/00000000-0000-0000-0000-000000000000" -b "$COOKIES"
+
+# victim jars (separate cookie jars from the smoke session)
+VICTIM_JAR="$(mktemp -t kanae-victim-cookies.XXXXXX)"
+SELF_JAR="$(mktemp -t kanae-self-cookies.XXXXXX)"
+trap 'rm -f "$COOKIES" "$VICTIM_JAR" "$SELF_JAR"' EXIT
+
+# ── victim 1: admin hard delete ───────────────────────────────────────────────
+register_victim "$VICTIM_JAR" "victim-$(date +%s)-$$@ucmerced.edu"
+VICTIM_ID="$REGISTERED_ID"
+ok "victim id: $VICTIM_ID"
+
+# root grants leads → 200, and the real Keto tuple resolves
+assert_http 200 PUT "$KANAE/members/$VICTIM_ID/role" \
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+ALLOWED=$(curl -s "$KETO_READ/relation-tuples/check?namespace=Role&object=leads&relation=member&subject_id=$VICTIM_ID" | jq -r '.allowed')
+[[ "$ALLOWED" == "true" ]] || fail "expected leads tuple for victim, got allowed=$ALLOWED"
+ok "victim granted leads (keto confirms)"
+
+# root hard-deletes the victim → 200
+assert_http 200 DELETE "$KANAE/members/$VICTIM_ID" -b "$COOKIES"
+
+GONE=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tA \
+	-c "SELECT 1 FROM members WHERE id = '$VICTIM_ID';" 2>/dev/null || true)
+[[ -z "$GONE" ]] || fail "victim members row still present after delete"
+ok "victim members row removed"
+
+# the real teardown removed the Kratos identity and swept the Keto tuples
+assert_http 404 GET "$KRATOS_ADMIN/admin/identities/$VICTIM_ID"
+ALLOWED_AFTER=$(curl -s "$KETO_READ/relation-tuples/check?namespace=Role&object=leads&relation=member&subject_id=$VICTIM_ID" | jq -r '.allowed')
+[[ "$ALLOWED_AFTER" == "false" ]] || fail "victim keto tuple survived purge (allowed=$ALLOWED_AFTER)"
+ok "kratos identity + keto tuples purged"
+
+# ── victim 2: self-service deletion via DELETE /members/me ─────────────────────
+register_victim "$SELF_JAR" "selfdel-$(date +%s)-$$@ucmerced.edu"
+SELF_ID="$REGISTERED_ID"
+ok "self-delete victim id: $SELF_ID"
+
+assert_http 200 DELETE "$KANAE/members/me" -b "$SELF_JAR"
+SELF_GONE=$(docker exec "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tA \
+	-c "SELECT 1 FROM members WHERE id = '$SELF_ID';" 2>/dev/null || true)
+[[ -z "$SELF_GONE" ]] || fail "self-delete members row still present"
+ok "self-service deletion removed members row"
+
+# ── 15. logout invalidates session (best-effort) ──────────────────────────────
 # Best-effort: a failure here means the session cookie is missing or already
 # expired, which is purely a kratos/curl-cookie-jar concern and tells us
 # nothing new about Kanae's behavior. The preceding 13 steps already cover

--- a/scripts/test-flow.sh
+++ b/scripts/test-flow.sh
@@ -388,6 +388,9 @@ warn "sudo: positive elevate path needs a fresh AAL2 (TOTP) session — not cove
 # the real Keto/Kratos teardown against throwaway victims.
 step "14. member management (role write + hard delete)"
 
+# Reused role-grant body for the member-management probes.
+LEADS_GRANT_BODY='{"role":"leads","action":"grant"}'
+
 register_victim() {
 	# register_victim <cookie-jar> <email>; sets REGISTERED_ID on success.
 	local jar="$1" email="$2" flow csrf resp row
@@ -415,12 +418,12 @@ register_victim() {
 
 # unauthenticated → 401 on both gated routes
 assert_http 401 PUT "$KANAE/members/$IDENTITY_ID/role" \
-	-H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+	-H "$H_CONTENT_TYPE" -d "$LEADS_GRANT_BODY"
 assert_http 401 DELETE "$KANAE/members/$IDENTITY_ID"
 
 # smoke identity is admin (not root, not sudo) → 403 on the gated route
 assert_http 403 PUT "$KANAE/members/$IDENTITY_ID/role" \
-	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d "$LEADS_GRANT_BODY"
 
 # promote smoke identity to root so it passes the member-management gate
 curl -sf -X PUT "$KETO_WRITE/admin/relation-tuples" \
@@ -431,7 +434,7 @@ ok "root tuple written, cache flushed"
 
 # self-guard: cannot modify or delete your own account via the admin route
 assert_http 409 PUT "$KANAE/members/$IDENTITY_ID/role" \
-	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d "$LEADS_GRANT_BODY"
 assert_http 409 DELETE "$KANAE/members/$IDENTITY_ID" -b "$COOKIES"
 
 # authorized but no such member → 404
@@ -449,7 +452,7 @@ ok "victim id: $VICTIM_ID"
 
 # root grants leads → 200, and the real Keto tuple resolves
 assert_http 200 PUT "$KANAE/members/$VICTIM_ID/role" \
-	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d '{"role":"leads","action":"grant"}'
+	-b "$COOKIES" -H "$H_CONTENT_TYPE" -d "$LEADS_GRANT_BODY"
 ALLOWED=$(curl -s "$KETO_READ/relation-tuples/check?namespace=Role&object=leads&relation=member&subject_id=$VICTIM_ID" | jq -r '.allowed')
 [[ "$ALLOWED" == "true" ]] || fail "expected leads tuple for victim, got allowed=$ALLOWED"
 ok "victim granted leads (keto confirms)"

--- a/src/routes/members.py
+++ b/src/routes/members.py
@@ -1,6 +1,7 @@
 import datetime
 import secrets
 import uuid
+from enum import StrEnum
 from typing import Annotated, Optional
 
 import asyncpg
@@ -10,13 +11,17 @@ from fastapi.responses import Response
 from pydantic import BaseModel
 
 from utils.auth import use_session
-from utils.errors import (
-    NotFoundError,
-    UnauthorizedError,
-)
-from utils.ory import KanaeSession
+from utils.checks import Role, check_any, has_role, has_sudo
+from utils.errors import ConflictError, NotFoundError, UnauthorizedError
+from utils.ory import KanaeSession, OryClient
 from utils.request import RouteRequest
-from utils.responses import NotFoundResponse, SuccessResponse, UnauthorizedResponse
+from utils.responses import (
+    ConflictResponse,
+    DeleteResponse,
+    NotFoundResponse,
+    SuccessResponse,
+    UnauthorizedResponse,
+)
 from utils.router import KanaeRouter
 
 from .events import Events, FullEvents
@@ -87,6 +92,15 @@ async def get_member_info(
     if not rows:
         raise NotFoundError
     return ClientMember(**(dict(rows)))
+
+
+async def purge_member(member_id: uuid.UUID, *, ory: OryClient) -> None:
+    # Ory Kratos and Keto won't take the raw UUID type but only a string
+    normalized_member_id = str(member_id)
+
+    await ory.revoke_all_sessions(normalized_member_id)
+    await ory.purge(normalized_member_id)
+    await ory.delete_identity(normalized_member_id)
 
 
 @router.get(
@@ -214,7 +228,105 @@ async def logout_member(
     if cookie:
         await request.app.ory.whoami.cache_invalidate(cookie)
 
-    return SuccessResponse(message="okie dokie")
+    return SuccessResponse(message="ok")
+
+
+class AssignableRole(StrEnum):
+    ADMIN = "admin"
+    MANAGER = "manager"
+    LEADS = "leads"
+
+
+class ModifyRoleAction(StrEnum):
+    GRANT = "grant"
+    REVOKE = "revoke"
+
+
+class ModifyRoleRequest(BaseModel, frozen=True):
+    role: AssignableRole
+    action: ModifyRoleAction
+
+
+@router.put(
+    "/members/{member_id}/role",
+    dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
+    responses={
+        200: {"model": SuccessResponse},
+        404: {"model": NotFoundResponse},
+        409: {"model": ConflictResponse},
+    },
+)
+@router.limiter.limit("5/minute")
+async def modify_member_role(
+    request: RouteRequest,
+    member_id: uuid.UUID,
+    req: ModifyRoleRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> SuccessResponse:
+    """Modify the role of a given member"""
+    if str(member_id) == session.identity.id:
+        msg = "Literally refusing to modify your own roles... You can't"
+        raise ConflictError(msg)
+
+    query = "SELECT 1 FROM members WHERE id = $1;"
+    if not await request.app.pool.fetchval(query, member_id):
+        raise NotFoundError
+
+    subject_id = str(member_id)
+    if req.action == ModifyRoleAction.GRANT:
+        await request.app.ory.grant("Role", req.role, "member", subject_id=subject_id)
+    else:
+        await request.app.ory.revoke("Role", req.role, "member", subject_id=subject_id)
+
+    return SuccessResponse(message="ok")
+
+
+@router.delete(
+    "/members/me",
+    responses={200: {"model": DeleteResponse}},
+)
+@router.limiter.limit("1/minute")
+async def delete_logged_account(
+    request: RouteRequest, session: Annotated[KanaeSession, Depends(use_session)]
+) -> DeleteResponse:
+    """Permanently delete the member associated the currently logged session"""
+    member_id = uuid.UUID(session.identity.id)
+
+    query = "DELETE FROM members WHERE id = $1;"
+    await purge_member(member_id, ory=request.app.ory)
+    await request.app.pool.execute(query, member_id)
+
+    return DeleteResponse(message="okie dokie")
+
+
+@router.delete(
+    "/members/{member_id}",
+    dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
+    responses={
+        200: {"model": DeleteResponse},
+        404: {"model": NotFoundResponse},
+        409: {"model": ConflictResponse},
+    },
+)
+@router.limiter.limit("1/minute")
+async def delete_member(
+    request: RouteRequest,
+    member_id: uuid.UUID,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> DeleteResponse:
+    """Permanently deletes an given member"""
+    if str(member_id) == session.identity.id:
+        msg = "Use DELETE /members/me to delete your own account"
+        raise ConflictError(msg)
+
+    query = "DELETE FROM members WHERE id = $1 RETURNING id;"
+
+    await purge_member(member_id, ory=request.app.ory)
+    response = await request.app.pool.fetchval(query, member_id)
+    if not response:
+        raise NotFoundError
+
+    return DeleteResponse(message="okie dokie")
 
 
 class _IdentityTraits(BaseModel, frozen=True, extra="forbid"):

--- a/src/routes/tags.py
+++ b/src/routes/tags.py
@@ -3,7 +3,7 @@ from typing import Annotated, Optional
 from fastapi import Path, Query
 from pydantic import BaseModel, Field
 
-from utils.checks import Role, has_role
+from utils.checks import Role, check_any, has_role, has_sudo
 from utils.errors import (
     NotFoundError,
 )
@@ -81,7 +81,7 @@ class ModifiedTag(BaseModel):
 
 @router.put(
     "/tags/{tag_id}",
-    dependencies=[has_role(Role.ADMIN)],
+    dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
     responses={200: {"model": Tags}, 404: {"model": NotFoundResponse}},
 )
 @router.limiter.limit("5/minute")
@@ -107,7 +107,7 @@ async def edit_tag(
 
 @router.delete(
     "/tags/{tag_id}",
-    dependencies=[has_role(Role.ADMIN)],
+    dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
     responses={200: {"model": DeleteResponse}, 404: {"model": NotFoundResponse}},
 )
 @router.limiter.limit("5/minute")
@@ -149,7 +149,7 @@ async def create_tags(
 
 @router.post(
     "/tags/bulk-create",
-    dependencies=[has_role(Role.ADMIN)],
+    dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
     responses={200: {"model": list[Tags]}},
 )
 @router.limiter.limit("1/minute")

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS events (
     end_at TIMESTAMP WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'utc'),
     location TEXT,
     type event_type DEFAULT 'misc',
-    creator_id UUID REFERENCES members (id) ON DELETE CASCADE ON UPDATE NO ACTION,
+    creator_id UUID REFERENCES members (id) ON DELETE SET NULL ON UPDATE NO ACTION,
     timezone TEXT DEFAULT 'UTC',
     thumbnail_hash TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'utc')
@@ -161,7 +161,7 @@ CREATE INDEX IF NOT EXISTS sudo_grants_expiry_idx ON sudo_grants (expires_at);
 
 CREATE TABLE IF NOT EXISTS sudo_audit (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    member_id UUID NOT NULL REFERENCES members(id),
+    member_id UUID REFERENCES members(id) ON DELETE SET NULL,
     reason TEXT NOT NULL,
     granted_at TIMESTAMP WITH TIME ZONE NOT NULL,
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL

--- a/src/utils/ory.py
+++ b/src/utils/ory.py
@@ -107,6 +107,11 @@ class OryClient:
             `glide.client`.
     """
 
+    _KRATOS_ADMIN_IDENTITIES = "/admin/identities/{id}"
+    _KETO_WRITE_RELATION = "/admin/relation-tuples"
+
+    _KETO_NAMESPACES = ("Role", "Project", "Event")
+
     def __init__(
         self, config: OryConfig, *, session: aiohttp.ClientSession, glide: GlideManager
     ) -> None:
@@ -276,7 +281,7 @@ class OryClient:
             404 (no such identity).
         """
         response = await self._request(
-            "GET", self.kratos_admin("/admin/identities/{id}", id=identity_id)
+            "GET", self.kratos_admin(self._KRATOS_ADMIN_IDENTITIES, id=identity_id)
         )
 
         if response.status == status.HTTP_404_NOT_FOUND:
@@ -342,7 +347,7 @@ class OryClient:
         payload = {"schema_id": "person", "traits": traits}
         response = await self._request(
             "PUT",
-            self.kratos_admin("/admin/identities/{id}", id=identity_id),
+            self.kratos_admin(self._KRATOS_ADMIN_IDENTITIES, id=identity_id),
             json=payload,
         )
 
@@ -357,6 +362,35 @@ class OryClient:
         identity = KratosIdentity.model_validate(data)
         await self.get_identity.cache_invalidate(identity_id)
         return identity
+
+    async def delete_identity(self, identity_id: str) -> None:
+        """Delete a Kratos identity and bust its cached entry.
+
+        Idempotent — a 404 from Kratos (identity already gone) is treated as
+        success, so repeated deletes of the same id do not raise. On
+        completion, calls :meth:`get_identity.cache_invalidate` so a stale
+        identity is not served from the cache after removal.
+
+        Args:
+            identity_id: Kratos identity UUID to delete.
+
+        Raises:
+            BadGatewayError: Kratos returned a status other than 204
+                (deleted) or 404 (already absent).
+        """
+        response = await self._request(
+            "DELETE", self.kratos_admin(self._KRATOS_ADMIN_IDENTITIES, id=identity_id)
+        )
+        response.release()
+
+        if response.status not in (
+            status.HTTP_204_NO_CONTENT,
+            status.HTTP_404_NOT_FOUND,
+        ):
+            msg = "Rejected identity delete request"
+            raise BadGatewayError(msg)
+
+        await self.get_identity.cache_invalidate(identity_id)
 
     ### Permission management via Keto
 
@@ -465,7 +499,7 @@ class OryClient:
             subject_set,
         )
         response = await self._request(
-            "DELETE", self.keto_write("/admin/relation-tuples").with_query(params)
+            "DELETE", self.keto_write(self._KETO_WRITE_RELATION).with_query(params)
         )
 
         if response.status == status.HTTP_400_BAD_REQUEST:
@@ -547,7 +581,7 @@ class OryClient:
         )
         response = await self._request(
             "PUT",
-            self.keto_write("/admin/relation-tuples"),
+            self.keto_write(self._KETO_WRITE_RELATION),
             json=payload,
         )
 
@@ -563,3 +597,44 @@ class OryClient:
             raise BadGatewayError(msg)
 
         await self._invalidate_resource(namespace, resource)
+
+    async def purge(self, subject_id: str) -> None:
+        """Delete every Keto relation tuple where `subject_id` is the subject.
+
+        Keto's delete endpoint rejects a subject-only query, so this issues one
+        scoped delete per OPL namespace (each filtered by `subject_id`),
+        removing the subject's roles and every owner/editor grant. Idempotent:
+        Keto returns 204 per namespace whether or not any tuple matched.
+
+        Note:
+            Unlike :meth:`revoke`, this performs **no** check-cache
+            invalidation. The only cached :meth:`check_permission` results it
+            could affect are keyed to this subject, which is expected to be
+            torn down entirely (sessions revoked, identity deleted) alongside
+            this call — so those entries are never read again and expire on
+            their own TTL.
+
+        Args:
+            subject_id: Identity UUID whose relation tuples should all be
+                removed.
+
+        Raises:
+            BadGatewayError: Keto returned a status other than 200 or 204 for
+                any namespace.
+        """
+        for namespace in self._KETO_NAMESPACES:
+            response = await self._request(
+                "DELETE",
+                self.keto_write(self._KETO_WRITE_RELATION).with_query(
+                    {"namespace": namespace, "subject_id": subject_id}
+                ),
+            )
+
+            response.release()
+
+            if response.status not in (
+                status.HTTP_200_OK,
+                status.HTTP_204_NO_CONTENT,
+            ):
+                msg = "Rejected subject purge request"
+                raise BadGatewayError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,13 +157,25 @@ class _FakeCacheableWhoami:
 
 
 class FakeOryClient:
-    __slots__ = ("client", "permissions", "revoked_sessions", "session", "whoami")
+    __slots__ = (
+        "client",
+        "deleted_identities",
+        "permissions",
+        "purged_subjects",
+        "revoked_all_sessions",
+        "revoked_sessions",
+        "session",
+        "whoami",
+    )
 
     def __init__(self, client: httpx.AsyncClient) -> None:
         self.client = client
         self.session: Optional[KanaeSession] = None
         self.permissions: set[_PermissionKey] = set()
         self.revoked_sessions: list[str] = []
+        self.revoked_all_sessions: list[str] = []
+        self.purged_subjects: list[str] = []
+        self.deleted_identities: list[str] = []
         self.whoami: _FakeCacheableWhoami = _FakeCacheableWhoami(self)
 
     async def check_permission(
@@ -230,6 +242,32 @@ class FakeOryClient:
             self.permissions.add(
                 _PermissionKey(namespace, str(resource), relation, str(subject_id))
             )
+
+    async def revoke(
+        self,
+        namespace: str,
+        resource: str,
+        relation: str,
+        subject_id: Optional[str] = None,
+        *,
+        subject_set: Optional[dict[str, str]] = None,
+    ) -> None:
+        if subject_id is not None:
+            self.permissions.discard(
+                _PermissionKey(namespace, str(resource), relation, str(subject_id))
+            )
+
+    async def revoke_all_sessions(self, identity_id: str) -> None:
+        self.revoked_all_sessions.append(identity_id)
+
+    async def purge(self, subject_id: str) -> None:
+        self.purged_subjects.append(subject_id)
+        self.permissions = {
+            key for key in self.permissions if key.subject_id != str(subject_id)
+        }
+
+    async def delete_identity(self, identity_id: str) -> None:
+        self.deleted_identities.append(identity_id)
 
 
 class KanaeTestClient:

--- a/tests/integration/init.sh
+++ b/tests/integration/init.sh
@@ -248,6 +248,15 @@ _garage_pid=$!
 			>/dev/null
 	done
 
+	root_admin=$(jq -n --arg ns Role --arg obj admin --arg rel member --arg subj "${IDS[root]}" '
+		{ namespace: $ns, object: $obj, relation: $rel, subject_id: $subj }')
+	curl -fsS \
+		-H 'Accept: application/json' \
+		-H 'Content-Type: application/json' \
+		-X PUT "$KETO_WRITE_URL/admin/relation-tuples" \
+		-d "$root_admin" \
+		>/dev/null
+
 	log "writing secrets (password + identity UUIDs) to $HURL_SECRETS_FILE"
 	{
 		printf 'PASSWORD=%s\n' "$PASSWORD"

--- a/tests/integration/init.sh
+++ b/tests/integration/init.sh
@@ -25,6 +25,7 @@ CONFIG_FILE="config.yml"
 CONFIG_DIST="config.dist.yml"
 HURL_VARS="tests/integration/vars.env"
 HURL_SECRETS_FILE="tests/integration/secrets.env"
+ACCEPT_JSON="Accept: application/json"
 
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
@@ -188,7 +189,7 @@ _garage_pid=$!
 		}')
 
 		resp=$(curl -sS -w '\n%{http_code}' \
-			-H 'Accept: application/json' \
+			-H "$ACCEPT_JSON" \
 			-H 'Content-Type: application/json' \
 			-X POST "$KRATOS_ADMIN_URL/admin/identities" \
 			-d "$body")
@@ -200,7 +201,7 @@ _garage_pid=$!
 				jq -r '.id' <<<"$body"
 				;;
 			409)
-				curl -fsS -H 'Accept: application/json' \
+				curl -fsS -H "$ACCEPT_JSON" \
 					"$KRATOS_ADMIN_URL/admin/identities?credentials_identifier=$email" \
 					| jq -r '.[0].id'
 				;;
@@ -241,7 +242,7 @@ _garage_pid=$!
 		body=$(jq -n --arg ns Role --arg obj "$role" --arg rel member --arg subj "$id" '
 		{ namespace: $ns, object: $obj, relation: $rel, subject_id: $subj }')
 		curl -fsS \
-			-H 'Accept: application/json' \
+			-H "$ACCEPT_JSON" \
 			-H 'Content-Type: application/json' \
 			-X PUT "$KETO_WRITE_URL/admin/relation-tuples" \
 			-d "$body" \
@@ -251,7 +252,7 @@ _garage_pid=$!
 	root_admin=$(jq -n --arg ns Role --arg obj admin --arg rel member --arg subj "${IDS[root]}" '
 		{ namespace: $ns, object: $obj, relation: $rel, subject_id: $subj }')
 	curl -fsS \
-		-H 'Accept: application/json' \
+		-H "$ACCEPT_JSON" \
 		-H 'Content-Type: application/json' \
 		-X PUT "$KETO_WRITE_URL/admin/relation-tuples" \
 		-d "$root_admin" \

--- a/tests/integration/scenarios/06_tag_admin_full_crud.hurl
+++ b/tests/integration/scenarios/06_tag_admin_full_crud.hurl
@@ -1,4 +1,5 @@
-# Full CRUD walk over /tags as ADMIN with every response shape and
+# Full CRUD walk over /tags as ROOT (the superuser fixture: tag create is
+# admin-gated, edit/delete are root/sudo-gated) with every response shape and
 # round-trip pinned. Exercises the role check, asyncpg upsert, the
 # returning-* row → Pydantic round-trip, the 404 + custom-detail
 # branch on edit-after-delete, and the no-implicit-sort order on
@@ -14,10 +15,10 @@ csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.valu
 POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
 Content-Type: application/json
 Accept: application/json
-{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
 HTTP 200
 [Asserts]
-jsonpath "$.session.identity.id" == "{{ADMIN_ID}}"
+jsonpath "$.session.identity.id" == "{{ROOT_ID}}"
 
 # Create — verify the returned row's shape exactly matches the request.
 POST {{KANAE_URL}}/tags/create

--- a/tests/integration/scenarios/08_tag_bulk_create.hurl
+++ b/tests/integration/scenarios/08_tag_bulk_create.hurl
@@ -23,7 +23,7 @@ csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.valu
 POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
 Content-Type: application/json
 Accept: application/json
-{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
 HTTP 200
 
 # Three-row bulk — verify exact response order matches request order,

--- a/tests/integration/scenarios/09_tag_validation_errors.hurl
+++ b/tests/integration/scenarios/09_tag_validation_errors.hurl
@@ -13,7 +13,7 @@ csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.valu
 POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
 Content-Type: application/json
 Accept: application/json
-{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
 HTTP 200
 
 # Missing required `description` field.

--- a/tests/integration/scenarios/20_nul_byte_rejected.hurl
+++ b/tests/integration/scenarios/20_nul_byte_rejected.hurl
@@ -18,7 +18,7 @@ csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.valu
 POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
 Content-Type: application/json
 Accept: application/json
-{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
 HTTP 200
 
 # Body NUL in tag title (\u0000 is valid JSON; decodes to a literal

--- a/tests/integration/scenarios/28_member_role_and_deletion.hurl
+++ b/tests/integration/scenarios/28_member_role_and_deletion.hurl
@@ -1,0 +1,116 @@
+# Sudo-gated member management: PUT /members/{id}/role + DELETE /members/{id}.
+#
+# Both routes gate on check_any(has_role(Role.ROOT), has_sudo()). Hurl can
+# satisfy the ROOT branch (bootstrapped root identity) but not the sudo branch
+# (needs a fresh AAL2/TOTP session), so this scenario covers the integration
+# concerns hurl is uniquely good at: real Keto role gating (401/403), the
+# self-modification guard (409), schema rejection of unassignable roles (422),
+# the not-found path (404), and a net-zero ROOT grant→verify→revoke that drives
+# the real Keto write path. The destructive delete + the /members/me
+# self-service flow are covered end-to-end by scripts/test-flow.sh and the unit
+# suite (tests/test_members.py), which can mint the sudo/AAL2 conditions hurl
+# cannot.
+
+# ── unauthenticated → 401 on every member-management route ────────────────────
+PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+Content-Type: application/json
+{ "role": "manager", "action": "grant" }
+HTTP 401
+
+DELETE {{KANAE_URL}}/members/{{MEMBER_ID}}
+HTTP 401
+
+DELETE {{KANAE_URL}}/members/me
+HTTP 401
+
+# ── MEMBER (no role tuple) → 403 on the sudo-gated routes ─────────────────────
+GET {{KRATOS_URL}}/self-service/login/browser
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{MEMBER_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+
+PUT {{KANAE_URL}}/members/{{ADMIN_ID}}/role
+Content-Type: application/json
+{ "role": "leads", "action": "grant" }
+HTTP 403
+
+DELETE {{KANAE_URL}}/members/{{ADMIN_ID}}
+HTTP 403
+
+# ── ROOT: guards + net-zero grant→verify→revoke on MEMBER ─────────────────────
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{ROOT_ID}}"
+
+# self-modification refused (the guard runs before any Keto/DB work)
+PUT {{KANAE_URL}}/members/{{ROOT_ID}}/role
+Content-Type: application/json
+{ "role": "manager", "action": "grant" }
+HTTP 409
+
+DELETE {{KANAE_URL}}/members/{{ROOT_ID}}
+HTTP 409
+
+# unassignable role rejected at validation — "root" is not an AssignableRole
+PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+Content-Type: application/json
+{ "role": "root", "action": "grant" }
+HTTP 422
+
+# unknown member → 404 (authorized, but no members row to act on)
+PUT {{KANAE_URL}}/members/00000000-0000-0000-0000-000000000000/role
+Content-Type: application/json
+{ "role": "manager", "action": "grant" }
+HTTP 404
+
+# unknown member DELETE → 404. Unlike the role-write 404 above (which stops at
+# the existence check), this runs purge_member() → Keto's per-namespace tuple
+# delete BEFORE the Postgres delete reports the missing row, so it's the
+# cheapest assertion that exercises the real purge path. Regression guard: purge
+# once issued a subject-only / undefined-namespace Keto delete that Keto 400'd,
+# surfacing as a 502 here instead of a 404.
+DELETE {{KANAE_URL}}/members/00000000-0000-0000-0000-000000000000
+HTTP 404
+
+# grant manager to MEMBER → 200
+PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+Content-Type: application/json
+{ "role": "manager", "action": "grant" }
+HTTP 200
+
+# the real Keto tuple now resolves (direct read, bypassing Kanae's cache)
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{MEMBER_ID}}
+HTTP 200
+[Asserts]
+jsonpath "$.allowed" == true
+
+# revoke it again → 200, restoring MEMBER to role-less for other scenarios
+PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+Content-Type: application/json
+{ "role": "manager", "action": "revoke" }
+HTTP 200
+
+# Keto's check endpoint signals the result via status: 200 allowed, 403 denied.
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{MEMBER_ID}}
+HTTP 403
+[Asserts]
+jsonpath "$.allowed" == false

--- a/tests/test_members.py
+++ b/tests/test_members.py
@@ -11,6 +11,8 @@ from blake3 import blake3
 from conftest import FakeOryClient, KanaeTestClient
 
 from core import Kanae
+from routes.members import ModifyRoleAction
+from utils.checks import Role
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -443,7 +445,7 @@ async def test_logout_revokes_session(
 
     response = await client.client.post("/members/logout")
     assert response.status_code == 200
-    assert response.json() == {"message": "okie dokie"}
+    assert response.json() == {"message": "ok"}
 
     assert fake_ory.revoked_sessions == [str(session_id)]
 
@@ -660,4 +662,239 @@ async def test_logout_enforces_3_per_minute(
             assert response.status_code == 200
 
         blocked = await client.client.post("/members/logout")
+        assert blocked.status_code == 429
+
+
+# ──────────────────────────────────────────────────────────────────
+# PUT /members/{member_id}/role — sudo-gated global role management
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_modify_role_requires_session(client: KanaeTestClient) -> None:
+    response = await client.client.put(
+        f"/members/{uuid.uuid4()}/role",
+        json={"role": "manager", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 401
+
+
+async def test_modify_role_rejects_unprivileged(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as()  # authenticated, but neither root nor sudo-elevated
+    response = await client.client.put(
+        f"/members/{uuid.uuid4()}/role",
+        json={"role": "manager", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 403
+
+
+async def test_modify_role_grant_succeeds_for_root(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+
+    response = await client.client.put(
+        f"/members/{target}/role",
+        json={"role": "manager", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 200
+    assert await fake_ory.check_permission("Role", "manager", "member", str(target))
+
+
+async def test_modify_role_revoke_succeeds_for_root(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+    await fake_ory.grant("Role", "leads", "member", subject_id=str(target))
+
+    response = await client.client.put(
+        f"/members/{target}/role",
+        json={"role": "leads", "action": ModifyRoleAction.REVOKE.value},
+    )
+    assert response.status_code == 200
+    assert not await fake_ory.check_permission("Role", "leads", "member", str(target))
+
+
+async def test_modify_role_grant_succeeds_via_sudo(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    admin_id = fake_ory.login_as(Role.ADMIN, aal="aal2")
+    await _insert_member(kanae.pool, member_id=uuid.UUID(admin_id))
+    await kanae.sudo.grant(admin_id, reason="manage roles")
+
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target, email="target@test.local")
+
+    response = await client.client.put(
+        f"/members/{target}/role",
+        json={"role": "admin", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 200
+    assert await fake_ory.check_permission("Role", "admin", "member", str(target))
+
+
+async def test_modify_role_404_when_member_missing(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    response = await client.client.put(
+        f"/members/{uuid.uuid4()}/role",
+        json={"role": "manager", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 404
+
+
+async def test_modify_role_refuses_self(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    identity_id = fake_ory.login_as(Role.ROOT)
+    response = await client.client.put(
+        f"/members/{identity_id}/role",
+        json={"role": "manager", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 409
+
+
+async def test_modify_role_rejects_unassignable_role(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+    response = await client.client.put(
+        f"/members/{target}/role",
+        json={"role": "root", "action": ModifyRoleAction.GRANT.value},
+    )
+    assert response.status_code == 422
+
+
+# ──────────────────────────────────────────────────────────────────
+# DELETE /members/me — self-service account deletion (auth-only)
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_delete_me_requires_session(client: KanaeTestClient) -> None:
+    response = await client.client.delete("/members/me")
+    assert response.status_code == 401
+
+
+async def test_delete_me_tears_down_and_removes_row(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    await _insert_member(kanae.pool, member_id=uuid.UUID(identity_id))
+
+    response = await client.client.delete("/members/me")
+    assert response.status_code == 200
+
+    remaining = await kanae.pool.fetchval(
+        "SELECT 1 FROM members WHERE id = $1", uuid.UUID(identity_id)
+    )
+    assert remaining is None
+    assert fake_ory.revoked_all_sessions == [identity_id]
+    assert fake_ory.purged_subjects == [identity_id]
+    assert fake_ory.deleted_identities == [identity_id]
+
+
+# ──────────────────────────────────────────────────────────────────
+# DELETE /members/{member_id} — sudo-gated administrative hard delete
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_delete_member_requires_session(client: KanaeTestClient) -> None:
+    response = await client.client.delete(f"/members/{uuid.uuid4()}")
+    assert response.status_code == 401
+
+
+async def test_delete_member_rejects_unprivileged(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as()
+    response = await client.client.delete(f"/members/{uuid.uuid4()}")
+    assert response.status_code == 403
+
+
+async def test_delete_member_succeeds_for_root(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+
+    response = await client.client.delete(f"/members/{target}")
+    assert response.status_code == 200
+
+    remaining = await kanae.pool.fetchval("SELECT 1 FROM members WHERE id = $1", target)
+    assert remaining is None
+    assert fake_ory.revoked_all_sessions == [str(target)]
+    assert fake_ory.purged_subjects == [str(target)]
+    assert fake_ory.deleted_identities == [str(target)]
+
+
+async def test_delete_member_404_when_missing(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    response = await client.client.delete(f"/members/{uuid.uuid4()}")
+    assert response.status_code == 404
+
+
+async def test_delete_member_refuses_self(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as(Role.ROOT)
+    await _insert_member(kanae.pool, member_id=uuid.UUID(identity_id))
+
+    response = await client.client.delete(f"/members/{identity_id}")
+    assert response.status_code == 409
+
+    # the self-guard runs before any teardown
+    assert fake_ory.purged_subjects == []
+    still_here = await kanae.pool.fetchval(
+        "SELECT 1 FROM members WHERE id = $1", uuid.UUID(identity_id)
+    )
+    assert still_here == 1
+
+
+# ──────────────────────────────────────────────────────────────────
+# Rate limits — role write 5/min, member delete 1/min
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_modify_role_enforces_5_per_minute(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+    body = {"role": "manager", "action": ModifyRoleAction.GRANT.value}
+
+    with hiro.Timeline().freeze():
+        for _ in range(5):
+            response = await client.client.put(f"/members/{target}/role", json=body)
+            assert response.status_code == 200
+
+        blocked = await client.client.put(f"/members/{target}/role", json=body)
+        assert blocked.status_code == 429
+
+
+async def test_delete_member_enforces_1_per_minute(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+
+    with hiro.Timeline().freeze():
+        first = await client.client.delete(f"/members/{target}")
+        assert first.status_code == 200
+
+        # the limiter buckets per-URL, so the second hit must reuse the same path
+        # to land in the same bucket; it is blocked before the handler runs.
+        blocked = await client.client.delete(f"/members/{target}")
         assert blocked.status_code == 429

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -132,7 +132,7 @@ async def test_create_tag_rejects_wrong_type(
 
 
 # ──────────────────────────────────────────────────────────────────
-# PUT /tags/{tag_id}  — admin only, 5/minute
+# PUT /tags/{tag_id}  — root/sudo-gated, 5/minute
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -156,7 +156,7 @@ async def test_edit_tag_rejects_non_admin(
 async def test_edit_tag_returns_404_when_missing(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     response = await client.client.put(
         "/tags/999999", json={"title": "x", "description": "y"}
     )
@@ -166,7 +166,7 @@ async def test_edit_tag_returns_404_when_missing(
 async def test_edit_tag_persists_changes(
     client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     tag_id: int = await kanae.pool.fetchval(
         "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
         "old-title",
@@ -188,13 +188,13 @@ async def test_edit_tag_persists_changes(
 async def test_edit_tag_rejects_invalid_payload(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     response = await client.client.put("/tags/1", json={"title": "only-title"})
     assert response.status_code == 422
 
 
 # ──────────────────────────────────────────────────────────────────
-# DELETE /tags/{tag_id}  — admin only, 5/minute
+# DELETE /tags/{tag_id}  — root/sudo-gated, 5/minute
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -214,7 +214,7 @@ async def test_delete_tag_rejects_non_admin(
 async def test_delete_tag_returns_404_when_missing(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     response = await client.client.delete("/tags/999999")
     assert response.status_code == 404
 
@@ -222,7 +222,7 @@ async def test_delete_tag_returns_404_when_missing(
 async def test_delete_tag_removes_row(
     client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     tag_id: int = await kanae.pool.fetchval(
         "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
         "trash",
@@ -238,7 +238,7 @@ async def test_delete_tag_removes_row(
 
 
 # ──────────────────────────────────────────────────────────────────
-# POST /tags/bulk-create  — admin only, 1/minute
+# POST /tags/bulk-create  — root/sudo-gated, 1/minute
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -264,7 +264,7 @@ async def test_bulk_create_rejects_non_admin(
 async def test_bulk_create_inserts_multiple_rows(
     client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     payload = [
         {"title": "alpha", "description": "first"},
         {"title": "beta", "description": "second"},
@@ -281,7 +281,7 @@ async def test_bulk_create_inserts_multiple_rows(
 async def test_bulk_create_rejects_non_list_payload(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     response = await client.client.post(
         "/tags/bulk-create",
         json={"title": "a", "description": "1"},
@@ -316,7 +316,7 @@ async def test_create_tag_enforces_5_per_minute(
 async def test_bulk_create_enforces_1_per_minute(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    fake_ory.login_as(Role.ADMIN)
+    fake_ory.login_as(Role.ROOT)
     with hiro.Timeline().freeze():
         first = await client.client.post(
             "/tags/bulk-create",


### PR DESCRIPTION
# Summary

Implement the check `check_any(has_role(Role.ROOT), has_sudo())` check as the sudo-level access check across our routes.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
