### PR TITLE
Properly initialize Garage clusters

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -6,33 +6,45 @@ include:
   
 services:
   kanae:
-     container_name: kanae
-     image: ghcr.io/ucmercedacm/kanae:latest
-     environment:
-       GRANIAN_WORKERS: ${KANAE_WORKERS:-1}
-     volumes:
-       # Do not edit the next line. If you want to change the path of the configuration file, please edit the CONFIG_LOCATION variable
-       - ${CONFIG_LOCATION}:/kanae/config.yml
-     ports:
-       - 8000:8000
-     networks:
-       - default
-       - db_bridge
-     depends_on:
-       database:
-         condition: service_healthy
-         restart: true
-       valkey:
-         condition: service_healthy
-         restart: true
-       kratos:
-         condition: service_started
-         restart: true
-       keto:
-         condition: service_started
-         restart: true
-       migrate:
-         condition: service_completed_successfully
+    container_name: kanae
+    image: ghcr.io/ucmercedacm/kanae:edge
+    environment:
+      GRANIAN_WORKERS: ${KANAE_WORKERS:-1}
+    volumes:
+      # Do not edit the next line. If you want to change the path of the configuration file, please edit the CONFIG_LOCATION variable
+      - ${CONFIG_LOCATION}:/kanae/config.yml
+    ports:
+      - 8000:8000
+      - 9555:9555
+    networks:
+      - default
+      - db_bridge
+    depends_on:
+      database:
+        condition: service_healthy
+        restart: true
+      valkey:
+        condition: service_healthy
+        restart: true
+      kratos:
+        condition: service_started
+        restart: true
+      keto:
+        condition: service_started
+        restart: true
+      garage:
+        condition: service_healthy
+        restart: true
+      garage-init:
+        condition: service_completed_successfully
+      migrate:
+        condition: service_completed_successfully
+    healthcheck: 
+      test: curl -fsS --max-time 2 http://127.0.0.1:8000
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
 
   database:
     container_name: kanae_postgres
@@ -74,7 +86,7 @@ services:
       timeout: 3s
       start_period: 10s
       start_interval: 3s
-  
+
   garage:
     container_name: kanae_garage
     image: dxflrs/garage:v2.3.0
@@ -90,7 +102,37 @@ services:
       - garage:/var/lib/garage/meta
       - ../garage.toml:/etc/garage.toml
     restart: unless-stopped
-    
+    healthcheck:
+      # As per Dockerfile: https://git.deuxfleurs.fr/Deuxfleurs/garage/src/branch/main-v2/Dockerfile
+      # There is no distro so we have to do this
+      test: ["CMD", "/garage", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  garage-init:
+    container_name: kanae_garage_init
+    build:
+      dockerfile_inline: |
+        FROM alpine:latest
+        RUN apk add --no-cache bash aws-cli yq
+        COPY --from=dxflrs/garage:v2.3.0 /garage /usr/local/bin/garage
+    entrypoint: bash /garage-init.sh
+    environment:
+      GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET}
+    volumes:
+      - ${CONFIG_LOCATION}:/kanae/config.yml:ro
+      - garage:/var/lib/garage/data
+      - garage:/var/lib/garage/meta
+      - ../garage.toml:/etc/garage.toml:ro
+      - ./garage-init.sh:/garage-init.sh:ro
+    network_mode: "service:garage"
+    depends_on:
+      garage:
+        condition: service_healthy
+    restart: "no"
+
 
   migrate:
     container_name: kanae_migrate
@@ -108,7 +150,7 @@ services:
       database:
         condition: service_healthy
     volumes:
-      - ../src/schema.sql:/schema.sql
+      - ../src/schema.sql:/schema.sql 
 
   prometheus:
     container_name: kanae_prometheus
@@ -132,6 +174,7 @@ services:
 
 volumes:
   database:
+  garage:
   prometheus-data:
   grafana-data:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ include:
 services:
   kanae:
     container_name: kanae
-    image: ghcr.io/ucmercedacm/kanae:latest
+    image: ghcr.io/ucmercedacm/kanae:edge
     environment:
       GRANIAN_WORKERS: ${KANAE_WORKERS:-1}
     volumes:
@@ -15,6 +15,7 @@ services:
       - ${CONFIG_LOCATION}:/kanae/config.yml
     ports:
       - 8000:8000
+      - 9555:9555
     networks:
       - default
       - db_bridge
@@ -31,8 +32,19 @@ services:
       keto:
         condition: service_started
         restart: true
+      garage:
+        condition: service_healthy
+        restart: true
+      garage-init:
+        condition: service_completed_successfully
       migrate:
         condition: service_completed_successfully
+    healthcheck: 
+      test: curl -fsS --max-time 2 http://127.0.0.1:8000
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
 
   database:
     container_name: kanae_postgres
@@ -90,7 +102,37 @@ services:
       - garage:/var/lib/garage/meta
       - ../garage.toml:/etc/garage.toml
     restart: unless-stopped
-    
+    healthcheck:
+      # As per Dockerfile: https://git.deuxfleurs.fr/Deuxfleurs/garage/src/branch/main-v2/Dockerfile
+      # There is no distro so we have to do this
+      test: ["CMD", "/garage", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  garage-init:
+    container_name: kanae_garage_init
+    build:
+      dockerfile_inline: |
+        FROM alpine:latest
+        RUN apk add --no-cache bash aws-cli yq
+        COPY --from=dxflrs/garage:v2.3.0 /garage /usr/local/bin/garage
+    entrypoint: bash /garage-init.sh
+    environment:
+      GARAGE_RPC_SECRET: ${GARAGE_RPC_SECRET}
+    volumes:
+      - ${CONFIG_LOCATION}:/kanae/config.yml:ro
+      - garage:/var/lib/garage/data
+      - garage:/var/lib/garage/meta
+      - ../garage.toml:/etc/garage.toml:ro
+      - ./garage-init.sh:/garage-init.sh:ro
+    network_mode: "service:garage"
+    depends_on:
+      garage:
+        condition: service_healthy
+    restart: "no"
+
 
   migrate:
     container_name: kanae_migrate
@@ -114,6 +156,7 @@ services:
 
 volumes:
   database:
+  garage:
 
 networks:
   db_bridge:

--- a/docker/garage-init.sh
+++ b/docker/garage-init.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG="${CONFIG:-/kanae/config.yml}"
+GARAGE_S3_URL="${GARAGE_S3_URL:-http://127.0.0.1:3900}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+
+GARAGE_KEY_ID=$(yq '.storage.key_id' "$CONFIG")
+GARAGE_SECRET_KEY=$(yq '.storage.secret_key' "$CONFIG")
+GARAGE_BUCKET=$(yq '.storage.bucket' "$CONFIG")
+GARAGE_PUBLIC_BUCKET=$(yq '.storage.public.bucket' "$CONFIG")
+export AWS_ACCESS_KEY_ID="$GARAGE_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$GARAGE_SECRET_KEY"
+
+if garage bucket info "$GARAGE_BUCKET" >/dev/null 2>&1; then
+	log "Garage already bootstrapped (bucket $GARAGE_BUCKET exists) — skipping init."
+	exit 0
+fi
+
+if garage layout show 2>/dev/null | grep -qi 'no nodes currently have a role'; then
+	NODE_ID=$(garage status 2>/dev/null \
+		| awk '/HEALTHY NODES/{f=2; next} f==2{f=1; next} f==1 && NF{print $1; exit}')
+	log "assigning layout to node: $NODE_ID"
+	garage layout assign -z dc1 -c 5G "$NODE_ID"
+	garage layout apply --version 1
+else
+	log "layout already applied — skipping assign/apply"
+fi
+
+if garage key info "$GARAGE_KEY_ID" >/dev/null 2>&1; then
+	log "access key $GARAGE_KEY_ID already imported — skipping"
+else
+	log "importing access key"
+	garage key import --yes -n kanae "$GARAGE_KEY_ID" "$GARAGE_SECRET_KEY"
+fi
+
+if garage bucket info "$GARAGE_BUCKET" >/dev/null 2>&1; then
+	log "private bucket $GARAGE_BUCKET already exists — skipping create"
+else
+	log "creating private bucket"
+	garage bucket create "$GARAGE_BUCKET"
+fi
+
+log "granting key access to private bucket"
+garage bucket allow --read --write --owner "$GARAGE_BUCKET" --key "$GARAGE_KEY_ID"
+
+log "setting private bucket CORS policy"
+aws s3api put-bucket-cors \
+	--endpoint-url "$GARAGE_S3_URL" \
+	--bucket "$GARAGE_BUCKET" \
+	--cors-configuration '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","PUT","HEAD"],"AllowedHeaders":["*"],"MaxAgeSeconds":3600}]}' \
+	--region garage
+
+log "setting private bucket lifecycle (abort stale multipart after 1 day)"
+aws s3api put-bucket-lifecycle-configuration \
+	--endpoint-url "$GARAGE_S3_URL" \
+	--bucket "$GARAGE_BUCKET" \
+	--lifecycle-configuration '{"Rules":[{"ID":"abort-stale-multipart","Status":"Enabled","Filter":{"Prefix":"media/"},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":1}}]}' \
+	--region garage
+
+if garage bucket info "$GARAGE_PUBLIC_BUCKET" >/dev/null 2>&1; then
+	log "public bucket $GARAGE_PUBLIC_BUCKET already exists — skipping create"
+else
+	log "creating public bucket for thumbnails"
+	garage bucket create "$GARAGE_PUBLIC_BUCKET"
+fi
+
+log "granting key access to public bucket + enabling website mode"
+garage bucket allow --read --write --owner "$GARAGE_PUBLIC_BUCKET" --key "$GARAGE_KEY_ID"
+garage bucket website --allow "$GARAGE_PUBLIC_BUCKET"
+
+log "setting public bucket CORS policy"
+aws s3api put-bucket-cors \
+	--endpoint-url "$GARAGE_S3_URL" \
+	--bucket "$GARAGE_PUBLIC_BUCKET" \
+	--cors-configuration '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":["*"],"MaxAgeSeconds":86400}]}' \
+	--region garage
+
+log "Garage setup complete."

--- a/scripts/test-images.sh
+++ b/scripts/test-images.sh
@@ -44,7 +44,19 @@ DB_NAME=${DB_NAME:-kanae}
 DB_USER=${DB_USER:-postgres}
 
 COOKIES="$(mktemp -t kanae-images-cookies.XXXXXX)"
-trap 'rm -f "$COOKIES"' EXIT
+
+# Presigned upload URLs are signed by kanae (in-container) against the internal
+# S3 host "garage:3900", which the host running this script can't resolve — a
+# bare PUT there fails with curl code 000. Rather than editing /etc/hosts, point
+# just this script's subprocesses at the published port via a private glibc
+# HOSTALIASES file: getaddrinfo redirects the single-label host "garage" to
+# localhost for both curl (single PUT) and Python's urllib (multipart), while the
+# Host header — and therefore the SigV4 signature — stays "garage:3900".
+HOSTALIASES_FILE="$(mktemp -t kanae-images-hostaliases.XXXXXX)"
+printf 'garage localhost\n' >"$HOSTALIASES_FILE"
+export HOSTALIASES="$HOSTALIASES_FILE"
+
+trap 'rm -f "$COOKIES" "$HOSTALIASES_FILE"' EXIT
 
 EMAIL="images-$(date +%s)-$$@ucmerced.edu"
 PASSWORD="correct-horse-battery-staple-2026"


### PR DESCRIPTION
# Summary

While in the process of upgrading the docker compose files, I noticed that we aren't actually initliazing the garage clusters. Now it's done so when you run the docker compose stack it should also now do it to reflect the changes needed.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
