### PR TITLE
Use external S3 endpoint for presigned URLs

### DIFF
--- a/config.dist.yml
+++ b/config.dist.yml
@@ -126,6 +126,15 @@ storage:
   # URL that points to the S3 object store. In this case, it's Garage.
   url: "http://localhost:3900"
 
+  # Externally-reachable S3 endpoint used ONLY to sign the presigned upload/download
+  # URLs handed to clients (browsers). Required. Distinct in purpose from `url` above:
+  # `url` is how Kanae itself reaches Garage; `presign_url` is the host clients must
+  # reach and the one baked into the signature.
+  #   - Single-host / local dev: same as `url`      (e.g. http://localhost:3900)
+  #   - Docker:                  the published host (http://localhost:3900, while `url` is http://garage:3900)
+  #   - k3s / prod:              the public Ingress  (https://s3.example.com,  while `url` is the in-cluster Service DNS)
+  presign_url: "http://localhost:3900"
+
   # Region that the S3 object store lives in.
   # For using Garage, leave it as "garage"
   region: "garage"

--- a/src/core.py
+++ b/src/core.py
@@ -246,6 +246,7 @@ class PublicConfig(TypedDict):
 
 class StorageConfig(BaseModel, frozen=True):
     url: str
+    presign_url: str
     region: str = "garage"
     bucket: str
     public: PublicConfig
@@ -520,10 +521,16 @@ class MultipartUploadChunks(NamedTuple):
 
 class StorageClient:
     def __init__(
-        self, config: StorageConfig, *, client: S3Client, glide: GlideManager
+        self,
+        config: StorageConfig,
+        *,
+        client: S3Client,
+        presign_client: S3Client,
+        glide: GlideManager,
     ) -> None:
         self.bucket = config.bucket
         self.client = client
+        self.presign_client = presign_client
 
         self.base_thumbnail_url = config.public["url"]
 
@@ -565,7 +572,7 @@ class StorageClient:
         Returns:
             str: Presigned URL the client uses to PUT the bytes directly.
         """
-        return await self.client.generate_presigned_url(
+        return await self.presign_client.generate_presigned_url(
             "put_object",
             Params={
                 "Bucket": self.bucket,
@@ -600,7 +607,7 @@ class StorageClient:
             UploadChunk(
                 index=index,
                 url=(
-                    await self.client.generate_presigned_url(
+                    await self.presign_client.generate_presigned_url(
                         "upload_part",
                         Params={**params, "PartNumber": index},
                         ExpiresIn=_PRESIGN_PUT_TTL,
@@ -744,7 +751,7 @@ class StorageClient:
         Returns:
             str: Presigned GET URL the client can use to read the object.
         """
-        return await self.client.generate_presigned_url(
+        return await self.presign_client.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": self.bucket,
@@ -1360,10 +1367,23 @@ class Kanae(FastAPI):
                 aws_secret_access_key=self.config.storage.secret_key,
                 config=AioConfig(signature_version="s3v4"),
             ) as s3_client,
+            self._boto_session.create_client(
+                "s3",
+                endpoint_url=self.config.storage.presign_url,
+                region_name=self.config.storage.region,
+                aws_access_key_id=self.config.storage.key_id,
+                aws_secret_access_key=self.config.storage.secret_key,
+                config=AioConfig(
+                    signature_version="s3v4", s3={"addressing_style": "path"}
+                ),
+            ) as presign_s3_client,
         ):
             app.ory = OryClient(self.config.ory, session=app.session, glide=app.glide)
             app.storage = StorageClient(
-                self.config.storage, client=s3_client, glide=app.glide
+                self.config.storage,
+                client=s3_client,
+                presign_client=presign_s3_client,
+                glide=app.glide,
             )
             self.sudo = SudoClient(app.pool)
             app.limiter.attach(app.glide)

--- a/tests/integration/init.sh
+++ b/tests/integration/init.sh
@@ -75,6 +75,7 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 	yq -i '.ory.keto_read_url    = "http://keto:4466"' "$CONFIG_FILE"
 	yq -i '.ory.keto_write_url   = "http://keto:4467"' "$CONFIG_FILE"
 	yq -i '.storage.url          = "http://garage:3900"' "$CONFIG_FILE"
+	yq -i '.storage.presign_url  = "http://localhost:3900"' "$CONFIG_FILE"
 	yq -i '.postgres_uri = "postgresql://postgres:password@database:5432/kanae"' "$CONFIG_FILE"
 
 	fresh_config=1


### PR DESCRIPTION
# Summary

Currently, we have presigned urls that handle our uploading and downloading. Before this PR, we were using the same S3 client connected to our internal address to create new presigned urls. This is fine if Kanae is running locally, but if it is running on Docker, or even K8s, it wouldn't work. That presigned url would use the internal address of our S3 bucket, and when the user gets it back, it resolved to the internal address rather than an external one. We can't change the host within the SigV4 signature (`X-Amz-SignedHeaders=host`), without entirely invalidating the original presigned url. Thus, a single S3 endpoint can't satisfy both internal operations and presigned urls.

So we define a new section within our config (known as `storage.presign_url`) that maps to our external address (say, `storage.ucmacm.dev`) to effectively send it as a proxy. As we are using presigned urls, there is no leak of internal media if any. Note that this DOES NOT affect thumbnails, as they live on the public bucket and therefore can be accessed publicly regardless of this change.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
