### PR TITLE
Fix flaky member-role integration test

### DIFF
--- a/tests/integration/init.sh
+++ b/tests/integration/init.sh
@@ -171,9 +171,10 @@ _garage_pid=$!
 		[manager]=MANAGER_EMAIL
 		[leads]=LEADS_EMAIL
 		[member]=MEMBER_EMAIL
+		[scratch]=SCRATCH_EMAIL
 	)
 	declare -A IDS=()
-	ROLE_ORDER=(root admin manager leads member)
+	ROLE_ORDER=(root admin manager leads member scratch)
 
 	create_or_lookup_identity() {
 		local role="$1" email="$2" body resp code
@@ -267,6 +268,7 @@ _garage_pid=$!
 		printf 'MANAGER_ID=%s\n' "${IDS[manager]}"
 		printf 'LEADS_ID=%s\n' "${IDS[leads]}"
 		printf 'MEMBER_ID=%s\n' "${IDS[member]}"
+		printf 'SCRATCH_ID=%s\n' "${IDS[scratch]}"
 	} >"$HURL_SECRETS_FILE"
 ) &
 _ory_pid=$!

--- a/tests/integration/scenarios/28_member_role_and_deletion.hurl
+++ b/tests/integration/scenarios/28_member_role_and_deletion.hurl
@@ -6,7 +6,10 @@
 # concerns hurl is uniquely good at: real Keto role gating (401/403), the
 # self-modification guard (409), schema rejection of unassignable roles (422),
 # the not-found path (404), and a net-zero ROOT grant→verify→revoke that drives
-# the real Keto write path. The destructive delete + the /members/me
+# the real Keto write path against a dedicated role-less `scratch` identity
+# (SCRATCH_ID) — kept distinct from `member` so this mutation never races the
+# role-less assertions other scenarios make about `member` under Hurl's
+# parallel --test execution. The destructive delete + the /members/me
 # self-service flow are covered end-to-end by scripts/test-flow.sh and the unit
 # suite (tests/test_members.py), which can mint the sudo/AAL2 conditions hurl
 # cannot.
@@ -91,26 +94,26 @@ HTTP 404
 DELETE {{KANAE_URL}}/members/00000000-0000-0000-0000-000000000000
 HTTP 404
 
-# grant manager to MEMBER → 200
-PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+# grant manager to SCRATCH → 200
+PUT {{KANAE_URL}}/members/{{SCRATCH_ID}}/role
 Content-Type: application/json
 { "role": "manager", "action": "grant" }
 HTTP 200
 
 # the real Keto tuple now resolves (direct read, bypassing Kanae's cache)
-GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{MEMBER_ID}}
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{SCRATCH_ID}}
 HTTP 200
 [Asserts]
 jsonpath "$.allowed" == true
 
-# revoke it again → 200, restoring MEMBER to role-less for other scenarios
-PUT {{KANAE_URL}}/members/{{MEMBER_ID}}/role
+# revoke it again → 200, restoring SCRATCH to role-less
+PUT {{KANAE_URL}}/members/{{SCRATCH_ID}}/role
 Content-Type: application/json
 { "role": "manager", "action": "revoke" }
 HTTP 200
 
 # Keto's check endpoint signals the result via status: 200 allowed, 403 denied.
-GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{MEMBER_ID}}
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{SCRATCH_ID}}
 HTTP 403
 [Asserts]
 jsonpath "$.allowed" == false

--- a/tests/integration/scenarios/29_member_directory_and_roles.hurl
+++ b/tests/integration/scenarios/29_member_directory_and_roles.hurl
@@ -6,9 +6,10 @@
 #
 # Bootstrapped state (tests/integration/init.sh): the members table holds
 # root/admin/manager/leads/member, and Keto grants admin->admin, manager->manager,
-# leads->leads, root->{root,admin}; member holds no role. Scenario 28 leaves
-# member role-less (its grant/revoke is net-zero), so the empty-set assertions
-# below are stable.
+# leads->leads, root->{root,admin}; member holds no role. No scenario ever grants
+# `member` a role — scenario 28's grant/revoke targets a dedicated `scratch`
+# identity instead — so the empty-set assertions below are stable even under
+# Hurl's parallel --test execution.
 
 # ── unauthenticated → 401 on both routes ──────────────────────────────────────
 GET {{KANAE_URL}}/members

--- a/tests/integration/vars.env
+++ b/tests/integration/vars.env
@@ -9,3 +9,4 @@ ADMIN_EMAIL=admin@hurl.test.local
 MANAGER_EMAIL=manager@hurl.test.local
 LEADS_EMAIL=leads@hurl.test.local
 MEMBER_EMAIL=member@hurl.test.local
+SCRATCH_EMAIL=scratch@hurl.test.local


### PR DESCRIPTION
# Summary

Scenario 29 fails as the shared member identity was used in scenario 28. It's possible to have scenario 28's changes be timed such as when scenario 29 is being ran, thus causing a race condition. Fix is to give scenario 28 it's own identity so this race condition can't happen anymore.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
