### PR TITLE
Implement checks for attached tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pyvips[binary]~=3.1.1",
     "pyyaml~=6.0.3",
     "uvloop~=0.22.1 ; sys_platform != 'win32'",
-    "valkey-glide~=2.5.0",
+    "valkey-glide==2.4.2",
     "winloop~=0.6.2 ; sys_platform == 'win32'",
 ]
 

--- a/src/core.py
+++ b/src/core.py
@@ -58,7 +58,7 @@ from pydantic import BaseModel
 from starlette.datastructures import Headers
 
 from utils.cache import ORJSONSerializer, ValkeyCache, cached_method
-from utils.errors import BadRequestError, NotFoundError
+from utils.errors import AttachedTagError, BadRequestError, NotFoundError
 from utils.glide import GlideManager
 from utils.limiter.extension import (
     KanaeLimiter,
@@ -1306,6 +1306,10 @@ class Kanae(FastAPI):
             self.invalid_hash_error_handler,  # ty: ignore[invalid-argument-type]
         )
         self.add_exception_handler(
+            AttachedTagError,
+            self.attached_tag_error_handler,  # ty: ignore[invalid-argument-type]
+        )
+        self.add_exception_handler(
             RateLimitExceeded,
             rate_limit_exceeded_handler,  # ty: ignore[invalid-argument-type]
         )
@@ -1353,6 +1357,17 @@ class Kanae(FastAPI):
         return ORJSONResponse(
             content={"error": "Failed to verify, entirely invalid hash"},
             status_code=status.HTTP_403_FORBIDDEN,
+        )
+
+    def attached_tag_error_handler(
+        self, request: RouteRequest, exc: AttachedTagError
+    ) -> Response:
+        return ORJSONResponse(
+            content={
+                "detail": exc.detail,
+                "entries": [entry.model_dump() for entry in exc.entries],
+            },
+            status_code=status.HTTP_409_CONFLICT,
         )
 
     def invalid_hash_error_handler(

--- a/src/routes/tags.py
+++ b/src/routes/tags.py
@@ -1,12 +1,11 @@
-from typing import Annotated, Optional
+import uuid
+from typing import Annotated, Literal, Optional
 
 from fastapi import Path, Query
 from pydantic import BaseModel, Field
 
 from utils.checks import Role, check_any, has_role, has_sudo
-from utils.errors import (
-    NotFoundError,
-)
+from utils.errors import AttachedTagError, NotFoundError
 from utils.request import RouteRequest
 from utils.responses import DeleteResponse, NotFoundResponse
 from utils.router import KanaeRouter
@@ -28,21 +27,32 @@ class Tags(BaseModel, frozen=True):
     description: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 
+class FullTags(BaseModel, frozen=True):
+    id: int
+    title: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    description: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    in_use: bool
+
+
 @router.get("/tags")
 async def get_tags(
     request: RouteRequest,
     title: Annotated[Optional[str], Query(min_length=3, pattern=_NO_NULL_REGEX)] = None,
-) -> list[Tags]:
+) -> list[FullTags]:
     """Get all tags that can be used or sort for a list of tags"""
     query = """
-    SELECT id, title, description
+    SELECT id, title, description,
+    (EXISTS (SELECT 1 FROM project_tags WHERE tag_id = tags.id)
+         OR EXISTS (SELECT 1 FROM event_tags WHERE tag_id = tags.id)) AS in_use
     FROM tags
     ORDER BY title DESC
     """
 
     if title:
         query = """
-        SELECT id, title, description
+        SELECT id, title, description,
+        (EXISTS (SELECT 1 FROM project_tags WHERE tag_id = tags.id)
+             OR EXISTS (SELECT 1 FROM event_tags WHERE tag_id = tags.id)) AS in_use
         FROM tags
         WHERE title % $1
         ORDER BY similarity(title, $1) DESC
@@ -50,20 +60,22 @@ async def get_tags(
 
     args: tuple[str, ...] = (title,) if title else ()
     records = await request.app.pool.fetch(query, *args)
-    return [Tags(**dict(row)) for row in records]
+    return [FullTags(**dict(row)) for row in records]
 
 
 @router.get(
     "/tags/{tag_id}",
-    responses={200: {"model": Tags}, 404: {"model": NotFoundResponse}},
+    responses={200: {"model": FullTags}, 404: {"model": NotFoundResponse}},
 )
 async def get_tag_by_id(
     request: RouteRequest,
     tag_id: Annotated[int, Path(ge=_TAG_ID_MIN, le=_TAG_ID_MAX)],
-) -> Tags:
+) -> FullTags:
     """Get tag via ID"""
     query = """
-    SELECT id, title, description
+    SELECT id, title, description,
+    (EXISTS (SELECT 1 FROM project_tags WHERE tag_id = tags.id)
+         OR EXISTS (SELECT 1 FROM event_tags WHERE tag_id = tags.id)) AS in_use
     FROM tags
     WHERE id = $1;
     """
@@ -71,7 +83,7 @@ async def get_tag_by_id(
     rows = await request.app.pool.fetchrow(query, tag_id)
     if not rows:
         raise NotFoundError
-    return Tags(**dict(rows))
+    return FullTags(**dict(rows))
 
 
 class ModifiedTag(BaseModel):
@@ -105,10 +117,25 @@ async def edit_tag(
     return Tags(**dict(rows))
 
 
+class AttachedTagEntry(BaseModel, frozen=True):
+    id: uuid.UUID
+    name: str
+    type: Literal["Project", "Event"]
+
+
+class AttachedTagResponse(BaseModel, frozen=True):
+    detail: str
+    entries: list[AttachedTagEntry]
+
+
 @router.delete(
     "/tags/{tag_id}",
     dependencies=[check_any(has_role(Role.ROOT), has_sudo())],
-    responses={200: {"model": DeleteResponse}, 404: {"model": NotFoundResponse}},
+    responses={
+        200: {"model": DeleteResponse},
+        404: {"model": NotFoundResponse},
+        409: {"model": AttachedTagResponse},
+    },
 )
 @router.limiter.limit("5/minute")
 async def delete_tag(
@@ -117,13 +144,42 @@ async def delete_tag(
 ) -> DeleteResponse:
     """Remove specified tag"""
     query = """
-    DELETE FROM tags
-    WHERE id = $1;
+    WITH usage AS (
+        SELECT projects.id, projects.name, 'Project' as type
+        FROM project_tags
+        JOIN projects ON projects.id = project_tags.project_id
+        WHERE project_tags.tag_id = $1
+
+        UNION ALL
+
+        SELECT events.id, events.name, 'Event' AS type
+        FROM event_tags
+        JOIN events ON events.id = event_tags.event_id
+        WHERE event_tags.tag_id = $1
+    ), deleted AS (
+        DELETE FROM tags
+        WHERE id = $1
+          AND NOT EXISTS (SELECT 1 FROM usage)
+        RETURNING id
+    )
+    SELECT
+        (SELECT jsonb_agg(jsonb_build_object('id', u.id, 'name', u.name, 'type', u.type))
+             FROM usage u) AS entries,
+        EXISTS (SELECT 1 FROM usage) AS in_use,
+        EXISTS (SELECT 1 FROM deleted) AS deleted;
     """
 
-    query_status = await request.app.pool.execute(query, tag_id)
-    if query_status[-1] == "0":
+    row = await request.app.pool.fetchrow(query, tag_id)
+
+    if row["in_use"]:
+        entries = [AttachedTagEntry(**entry) for entry in row["entries"]]
+
+        msg = "Tag is still in use"
+        raise AttachedTagError(msg, entries=entries)
+
+    if not row["deleted"]:
         raise NotFoundError
+
     return DeleteResponse()
 
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -131,7 +131,7 @@ CREATE INDEX IF NOT EXISTS projects_name_trgm_idx ON projects USING gin (name gi
 -- Meaning that many projects can have many tags
 -- This basically implies that we need bridge tables to overcome the gap.
 CREATE TABLE IF NOT EXISTS tags (
-    id SERIAL PRIMARY KEY,
+    id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     title TEXT NOT NULL,
     description TEXT
 );

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -10,6 +10,8 @@ from .responses import HTTP_404_DETAIL
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from routes.tags import AttachedTagEntry
+
     from .checks import CheckContext, CheckPredicate, ResourcePermission, Role
 
 
@@ -53,6 +55,12 @@ class ConflictError(BaseHTTPException):
     def __init__(self, detail: str) -> None:
         super().__init__(detail)
         self.status_code = 409
+
+
+class AttachedTagError(ConflictError):
+    def __init__(self, detail: str, *, entries: list[AttachedTagEntry]) -> None:
+        super().__init__(detail)
+        self.entries = entries
 
 
 # HTTP 502

--- a/tests/integration/scenarios/06_tag_admin_full_crud.hurl
+++ b/tests/integration/scenarios/06_tag_admin_full_crud.hurl
@@ -34,20 +34,23 @@ jsonpath "$.id" > 0
 jsonpath "$.title" == "scenario07-rust"
 jsonpath "$.description" == "systems language"
 
-# Get-by-id round-trip.
+# Get-by-id round-trip. Now carries in_use (FullTags) — a freshly created,
+# unattached tag is not in use.
 GET {{KANAE_URL}}/tags/{{tag_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == {{tag_id}}
 jsonpath "$.title" == "scenario07-rust"
 jsonpath "$.description" == "systems language"
+jsonpath "$.in_use" == false
 
-# Listing reflects the new row.
+# Listing reflects the new row and every row carries the in_use flag.
 GET {{KANAE_URL}}/tags
 HTTP 200
 [Asserts]
 jsonpath "$" isCollection
 body contains "scenario07-rust"
+jsonpath "$[0].in_use" isBoolean
 
 # Filter by similarity returns at least one match.
 GET {{KANAE_URL}}/tags?title=scenario07-rust

--- a/tests/integration/scenarios/40_tag_delete_in_use_conflict.hurl
+++ b/tests/integration/scenarios/40_tag_delete_in_use_conflict.hurl
@@ -1,0 +1,96 @@
+# Deleting a tag that is still attached to a project/event must 409 with the
+# AttachedTagResponse shape (detail + entries[]), leaving the tag intact —
+# rather than silently deleting or 500-ing on the bridge FK. Once the tag is
+# detached it deletes cleanly. Driven entirely as ROOT (superuser satisfies the
+# admin create gate, owns the event it creates → Event.edit, and is root for
+# the delete). The delete route is 5/min; this uses 2 of that bucket.
+
+GET {{KRATOS_URL}}/self-service/login/browser
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{ROOT_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{ROOT_ID}}"
+
+# Fresh tag — nothing references it yet, so in_use is false.
+POST {{KANAE_URL}}/tags/create
+Content-Type: application/json
+{ "title": "scenario40-inuse", "description": "attached to an event" }
+HTTP 200
+[Captures]
+tag_id: jsonpath "$.id"
+
+GET {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.in_use" == false
+
+# Create an event owned by ROOT and attach the tag to it.
+POST {{KANAE_URL}}/events/create
+Content-Type: application/json
+{
+  "id": "40404040-4040-4040-8040-404040404040",
+  "name": "scenario40-tagged-event",
+  "description": "holds the tag hostage",
+  "start_at": "2099-06-01T00:00:00Z",
+  "end_at":   "2099-06-01T03:00:00Z",
+  "location": "Online",
+  "type": "general",
+  "timezone": "UTC",
+  "creator_id": "{{ROOT_ID}}"
+}
+HTTP 200
+[Captures]
+event_id: jsonpath "$.id"
+
+PUT {{KANAE_URL}}/events/{{event_id}}/tags
+Content-Type: application/json
+{ "tags": ["scenario40-inuse"] }
+HTTP 200
+
+# The tag now reports in_use.
+GET {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.in_use" == true
+
+# Delete is blocked: 409 + the AttachedTagResponse listing the event that
+# references it. The tag row must survive.
+DELETE {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 409
+[Asserts]
+jsonpath "$.detail" == "Tag is still in use"
+jsonpath "$.entries" isCollection
+jsonpath "$.entries" count == 1
+jsonpath "$.entries[0].id" == "{{event_id}}"
+jsonpath "$.entries[0].name" == "scenario40-tagged-event"
+jsonpath "$.entries[0].type" == "Event"
+
+GET {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == {{tag_id}}
+jsonpath "$.in_use" == true
+
+# Detach the tag, then the same delete succeeds with the {message: "ok"} shape.
+DELETE {{KANAE_URL}}/events/{{event_id}}/tags
+HTTP 200
+
+DELETE {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 200
+[Asserts]
+jsonpath "$.message" == "ok"
+
+# And it is really gone.
+GET {{KANAE_URL}}/tags/{{tag_id}}
+HTTP 404
+[Asserts]
+jsonpath "$.result" == "error"

--- a/tests/integration/scenarios/40_tag_delete_in_use_conflict.hurl
+++ b/tests/integration/scenarios/40_tag_delete_in_use_conflict.hurl
@@ -68,6 +68,9 @@ DELETE {{KANAE_URL}}/tags/{{tag_id}}
 HTTP 409
 [Asserts]
 jsonpath "$.detail" == "Tag is still in use"
+# attached_tag_error_handler renders the AttachedTagResponse shape directly:
+# detail + entries, and NOT the "result" key the generic error handler adds.
+jsonpath "$.result" not exists
 jsonpath "$.entries" isCollection
 jsonpath "$.entries" count == 1
 jsonpath "$.entries[0].id" == "{{event_id}}"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -39,6 +39,59 @@ async def test_list_tags_returns_seeded_rows(
     assert {row["title"] for row in body} == {"python", "rust"}
 
 
+async def test_list_tags_reports_in_use_flag(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    attached_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "attached",
+        "used by a project",
+    )
+    await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "orphan",
+        "used by nothing",
+    )
+    project_id = await kanae.pool.fetchval(
+        "INSERT INTO projects (name) VALUES ($1) RETURNING id", "some project"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO project_tags (project_id, tag_id) VALUES ($1, $2)",
+        project_id,
+        attached_id,
+    )
+
+    response = await client.client.get("/tags")
+    assert response.status_code == 200
+    in_use = {row["title"]: row["in_use"] for row in response.json()}
+    assert in_use == {"attached": True, "orphan": False}
+
+
+async def test_list_tags_title_filter_includes_in_use(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    # The similarity-search branch must also carry the in_use column.
+    tag_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "python",
+        "the lang",
+    )
+    event_id = await kanae.pool.fetchval(
+        "INSERT INTO events (name) VALUES ($1) RETURNING id", "some event"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO event_tags (event_id, tag_id) VALUES ($1, $2)",
+        event_id,
+        tag_id,
+    )
+
+    response = await client.client.get("/tags?title=python")
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert body[0]["title"] == "python"
+    assert body[0]["in_use"] is True
+
+
 async def test_list_tags_rejects_short_title_filter(client: KanaeTestClient) -> None:
     # `title` has Query(min_length=3) — two chars must 422
     response = await client.client.get("/tags?title=py")
@@ -58,7 +111,34 @@ async def test_get_tag_by_id_returns_row(client: KanaeTestClient, kanae: Kanae) 
     )
     response = await client.client.get(f"/tags/{tag_id}")
     assert response.status_code == 200
-    assert response.json() == {"id": tag_id, "title": "go", "description": "a lang"}
+    assert response.json() == {
+        "id": tag_id,
+        "title": "go",
+        "description": "a lang",
+        "in_use": False,
+    }
+
+
+async def test_get_tag_by_id_reports_in_use(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    tag_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "attached",
+        "used by an event",
+    )
+    event_id = await kanae.pool.fetchval(
+        "INSERT INTO events (name) VALUES ($1) RETURNING id", "some event"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO event_tags (event_id, tag_id) VALUES ($1, $2)",
+        event_id,
+        tag_id,
+    )
+
+    response = await client.client.get(f"/tags/{tag_id}")
+    assert response.status_code == 200
+    assert response.json()["in_use"] is True
 
 
 async def test_get_tag_by_id_returns_404_when_missing(client: KanaeTestClient) -> None:
@@ -235,6 +315,66 @@ async def test_delete_tag_removes_row(
         "SELECT count(*) FROM tags WHERE id = $1", tag_id
     )
     assert remaining == 0
+
+
+async def test_delete_tag_in_use_by_project_returns_409(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    tag_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "pinned",
+        "attached to a project",
+    )
+    project_id = await kanae.pool.fetchval(
+        "INSERT INTO projects (name) VALUES ($1) RETURNING id", "kanae"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO project_tags (project_id, tag_id) VALUES ($1, $2)",
+        project_id,
+        tag_id,
+    )
+
+    response = await client.client.delete(f"/tags/{tag_id}")
+    assert response.status_code == 409
+    body: dict[str, Any] = response.json()
+    assert body["detail"] == "Tag is still in use"
+    assert body["entries"] == [
+        {"id": str(project_id), "name": "kanae", "type": "Project"}
+    ]
+
+    # The conflict must leave the tag intact.
+    remaining: int = await kanae.pool.fetchval(
+        "SELECT count(*) FROM tags WHERE id = $1", tag_id
+    )
+    assert remaining == 1
+
+
+async def test_delete_tag_in_use_by_event_returns_409(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ROOT)
+    tag_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "pinned",
+        "attached to an event",
+    )
+    event_id = await kanae.pool.fetchval(
+        "INSERT INTO events (name) VALUES ($1) RETURNING id", "orientation"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO event_tags (event_id, tag_id) VALUES ($1, $2)",
+        event_id,
+        tag_id,
+    )
+
+    response = await client.client.delete(f"/tags/{tag_id}")
+    assert response.status_code == 409
+    body: dict[str, Any] = response.json()
+    assert body["detail"] == "Tag is still in use"
+    assert body["entries"] == [
+        {"id": str(event_id), "name": "orientation", "type": "Event"}
+    ]
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -337,11 +337,10 @@ async def test_delete_tag_in_use_by_project_returns_409(
 
     response = await client.client.delete(f"/tags/{tag_id}")
     assert response.status_code == 409
-    body: dict[str, Any] = response.json()
-    assert body["detail"] == "Tag is still in use"
-    assert body["entries"] == [
-        {"id": str(project_id), "name": "kanae", "type": "Project"}
-    ]
+    assert response.json() == {
+        "detail": "Tag is still in use",
+        "entries": [{"id": str(project_id), "name": "kanae", "type": "Project"}],
+    }
 
     # The conflict must leave the tag intact.
     remaining: int = await kanae.pool.fetchval(
@@ -370,11 +369,51 @@ async def test_delete_tag_in_use_by_event_returns_409(
 
     response = await client.client.delete(f"/tags/{tag_id}")
     assert response.status_code == 409
-    body: dict[str, Any] = response.json()
-    assert body["detail"] == "Tag is still in use"
-    assert body["entries"] == [
-        {"id": str(event_id), "name": "orientation", "type": "Event"}
-    ]
+    assert "result" not in response.json()  # dedicated handler, not the generic one
+    assert response.json() == {
+        "detail": "Tag is still in use",
+        "entries": [{"id": str(event_id), "name": "orientation", "type": "Event"}],
+    }
+
+
+async def test_delete_tag_in_use_lists_every_attachment(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    # A tag attached to both a project and an event surfaces both in entries —
+    # exercises the UNION ALL (projects first, then events) and the handler
+    # serializing more than one entry.
+    fake_ory.login_as(Role.ROOT)
+    tag_id: int = await kanae.pool.fetchval(
+        "INSERT INTO tags (title, description) VALUES ($1, $2) RETURNING id",
+        "pinned",
+        "attached to both",
+    )
+    project_id = await kanae.pool.fetchval(
+        "INSERT INTO projects (name) VALUES ($1) RETURNING id", "kanae"
+    )
+    event_id = await kanae.pool.fetchval(
+        "INSERT INTO events (name) VALUES ($1) RETURNING id", "orientation"
+    )
+    await kanae.pool.execute(
+        "INSERT INTO project_tags (project_id, tag_id) VALUES ($1, $2)",
+        project_id,
+        tag_id,
+    )
+    await kanae.pool.execute(
+        "INSERT INTO event_tags (event_id, tag_id) VALUES ($1, $2)",
+        event_id,
+        tag_id,
+    )
+
+    response = await client.client.delete(f"/tags/{tag_id}")
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Tag is still in use",
+        "entries": [
+            {"id": str(project_id), "name": "kanae", "type": "Project"},
+            {"id": str(event_id), "name": "orientation", "type": "Event"},
+        ],
+    }
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -216,11 +216,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
-[package.optional-dependencies]
-trio = [
-    { name = "trio" },
-]
-
 [[package]]
 name = "argon2-cffi"
 version = "25.1.0"
@@ -1203,7 +1198,7 @@ requires-dist = [
     { name = "pyvips", extras = ["binary"], specifier = "~=3.1.1" },
     { name = "pyyaml", specifier = "~=6.0.3" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = "~=0.22.1" },
-    { name = "valkey-glide", specifier = "~=2.5.0" },
+    { name = "valkey-glide", specifier = "==2.4.2" },
     { name = "winloop", marker = "sys_platform == 'win32'", specifier = "~=0.6.2" },
 ]
 
@@ -1492,18 +1487,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
     { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
     { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
-]
-
-[[package]]
-name = "outcome"
-version = "1.3.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
 ]
 
 [[package]]
@@ -2247,23 +2230,6 @@ wheels = [
 ]
 
 [[package]]
-name = "trio"
-version = "0.33.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
-    { name = "idna" },
-    { name = "outcome" },
-    { name = "sniffio" },
-    { name = "sortedcontainers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
-]
-
-[[package]]
 name = "ty"
 version = "0.0.61"
 source = { registry = "https://pypi.org/simple" }
@@ -2423,28 +2389,27 @@ wheels = [
 
 [[package]]
 name = "valkey-glide"
-version = "2.5.0"
+version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", extra = ["trio"] },
-    { name = "cffi" },
+    { name = "anyio" },
     { name = "protobuf" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/17/a35fb268674478969af6e5ec4a27504d50bb056e3242e12d37152d95fb10/valkey_glide-2.5.0.tar.gz", hash = "sha256:21a9c037107af5ba3cdb27ed126abc02c75f9690dd6e82272f2a91042f4b8a2e", size = 997147, upload-time = "2026-07-14T18:49:37.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/df/b62875d6b6e98ba10b7074af80a951bce624d7b6d9f9f840771bb09814da/valkey_glide-2.4.2.tar.gz", hash = "sha256:d63a7483c2db59d8c73666a360246cadaac82b6d71087d75839395ffacf863e0", size = 894164, upload-time = "2026-06-26T19:22:02.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/12/6edae2f81d1dfcc6a82296b0114dd23bc05fba0f588effc65d28859be66b/valkey_glide-2.5.0-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:95bc800473d5795e3db5eb9f64892cc0c4b79a4580320d51c90799f05ca815b9", size = 14171806, upload-time = "2026-07-14T18:48:53.888Z" },
-    { url = "https://files.pythonhosted.org/packages/02/0f/ce679d3757df9fe442c7a40ab8ddde1041b88ae94beb26880562cd2eb080/valkey_glide-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ea98b2b44bbfdfdc4fa6149b16136f67c59dd46e51f4e45c29136307c3177a3a", size = 13210068, upload-time = "2026-07-14T18:48:55.964Z" },
-    { url = "https://files.pythonhosted.org/packages/55/56/23ac9bc1df706fbe0f81eb7df7095ad31d8909160bee3f87cd17fc002a16/valkey_glide-2.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9db2235a3190ec0b5bf3997c518a6c642f5e44c3a3c1ed70817ce5fc48815e6", size = 14210823, upload-time = "2026-07-14T18:48:57.9Z" },
-    { url = "https://files.pythonhosted.org/packages/13/ee/3fbff5fb95be1607ea240ed60fa63700fd36b863870eb79606613bb38975/valkey_glide-2.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7893d63a3424ea43f9e2ab7ce2e31d628dea765f0ada09ab1b50b426f55d3863", size = 14959240, upload-time = "2026-07-14T18:48:59.93Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ca/62399b08d21acafeb2ac9cc4bc0fb3ba21f332dc755bbc2ee4f9e526fd98/valkey_glide-2.5.0-cp313-cp313-macosx_10_7_x86_64.whl", hash = "sha256:cc6146d78545a85da2757ba0ac9d636b90fabdb45cc1a864f1c808381de942c5", size = 14171922, upload-time = "2026-07-14T18:49:02.227Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/af/716d81018ea6f5385301b99179da8f0a00bc3485b2f1f94e98c90aa9e285/valkey_glide-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d8feb2a5ace38d1d88ba5c650b10273c5d862a55b0b5006d227aadd91e7c31e7", size = 13210072, upload-time = "2026-07-14T18:49:04.336Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/65/cb9a634cbad83f3c5b4701d8d257cd7fa106cf57b19a512de131679c5efa/valkey_glide-2.5.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bc80db5b2c191550ed716d28018520c7decc7853a2c2104c2d3654da3cd920e", size = 14210705, upload-time = "2026-07-14T18:49:06.571Z" },
-    { url = "https://files.pythonhosted.org/packages/77/b6/b5bda49f5f2f7f94a25f02c9f0b03a21578524c2bdb62fe9ff4385140097/valkey_glide-2.5.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afecb53f774e7e376a757cda124bc08734b072cfdfcf703111b26afab5c24d2d", size = 14959473, upload-time = "2026-07-14T18:49:09.2Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/d4/a3b4d2cbc020b094d438cf55c30bac6aa0456354b5f78bd88375d5ebcacd/valkey_glide-2.5.0-cp314-cp314-macosx_10_7_x86_64.whl", hash = "sha256:4a86f8451c5f8aa69f822782ba0ab64c77d8f6267844e2479b3267853dd076a5", size = 14171300, upload-time = "2026-07-14T18:49:11.175Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3c/b835dff29f40e1b3c9ff250ca10e99b4c3e1ffe3d6378617190d0adbea68/valkey_glide-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97b1d1bde85abf9783952e65b134368d0a575b5978b73c60fdde1d69d6bc6a69", size = 13202349, upload-time = "2026-07-14T18:49:13.281Z" },
-    { url = "https://files.pythonhosted.org/packages/22/bf/58b5a4e7bfaf59d98a28eb1df3f4c232a833878c4ae52e0c66db9641548f/valkey_glide-2.5.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2d442a9aa0a2685023850950d76acaa689df1581f3028468c965e71b9009a83", size = 14219822, upload-time = "2026-07-14T18:49:15.443Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/84/62ab84e0f265ab74f63817e5ca85893de8413bc68d6c1ec23573010e651e/valkey_glide-2.5.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c90d9bb9c49059f0ddd8b50b1e84e924c7a8bd261be82376ab09cefbbf2b233", size = 14959688, upload-time = "2026-07-14T18:49:17.68Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/71/ca3309428bd221ea1fdf12f84874be034008df163aa3736f1b7cc29da93b/valkey_glide-2.4.2-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:ba1f7ca94ec120169019656ad71fba19bcef13c18180f89e4320f431aa9fb9df", size = 7518921, upload-time = "2026-06-26T19:21:29.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c0/dfcafce4b64adc704dc6ed26ae622996d67b7333970a5dcf252bd06f9a84/valkey_glide-2.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3f6c51bf6fd5b73978e2d24ea40b36931cfafa96158380b9e7cba15c645c63c4", size = 6962771, upload-time = "2026-06-26T19:21:31.365Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ee/369bab4baef737d3a5fe9d73a7a012d3616c679f3cf449a25d14d47325b5/valkey_glide-2.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be07848c279b8bb33b80466d56899ed0df41c98fae090817df88787928ac7774", size = 7266588, upload-time = "2026-06-26T19:21:32.884Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/4942619ab48d7f534598743533ab8299bfa1e9bea7dec66fe79042dab75b/valkey_glide-2.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d264a886940cec2c52f5332dfc431b82342cc23e3ea8e3aefc0e762cb4379ed8", size = 7706618, upload-time = "2026-06-26T19:21:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/43/9d/5721042d5642b924bf15f05441f850e2ca404bdba990d727713def3518cf/valkey_glide-2.4.2-cp313-cp313-macosx_10_7_x86_64.whl", hash = "sha256:4f84e94dfe1e9713701e85e7b80cc1526e8f73b5eac7ea84ed544d5918b1dc97", size = 7519180, upload-time = "2026-06-26T19:21:36.187Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c7/5fc34087202843bc8aea10bfd751a3138bb5410b5ac15d8f8b694a3bef2d/valkey_glide-2.4.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:20136ce5cf682747bf39fc2b863cccaa2a1f873c8fbf67828d28d13a3d893b4b", size = 6962978, upload-time = "2026-06-26T19:21:37.729Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/15224ccaba81122ac7b6b5fc77c46a97d175d76b7029c3c97f203e099f6a/valkey_glide-2.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:044375a86e29af4707babdc8d022ae3a7e74772634a8104dd1ab86dda48a4dfe", size = 7266837, upload-time = "2026-06-26T19:21:39.304Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/29/ba4246d742893be167629549d232b22d48ecca60baf6565036291440dcb7/valkey_glide-2.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3d11e84fd13938c23721f070fd45d8d3f3b940fc31120ba2749a9cc89398f48", size = 7706178, upload-time = "2026-06-26T19:21:40.824Z" },
+    { url = "https://files.pythonhosted.org/packages/80/67/1f5d09f1dbea743e57d9f4d661afd4e1397568343919fe90cf7ba9246bd8/valkey_glide-2.4.2-cp314-cp314-macosx_10_7_x86_64.whl", hash = "sha256:a413130a4ea71e915b1fc20d79eb2c53f4f02eab15ef375c5ef81399d3a10445", size = 7516994, upload-time = "2026-06-26T19:21:42.394Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6e/85ba9ea7b41694e97d6ad03ad720aaf12a6c842a237df61319ebe6dc4021/valkey_glide-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:650b9cd31bdc816049f348bddc556af71af88e44d0924211843080e47d4c2ae7", size = 6958287, upload-time = "2026-06-26T19:21:43.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a1/4877e6c74d518395d63b42f2b368685b4685a7d820c67d2a681122018b2b/valkey_glide-2.4.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:284970736d5c6d7e9af91dbca1f5907c718bade1df11d7a0f42960adc5670e87", size = 7266347, upload-time = "2026-06-26T19:21:46.009Z" },
+    { url = "https://files.pythonhosted.org/packages/38/88/e6f67b89e7be67d55d91a0c4107e42aa9ad79b4de55b20bd7c39f3311f82/valkey_glide-2.4.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33742e9bc3f7c5131e2cb4e0b17f8ba5c6c0ee16bd534cf68abe68853cde27f1", size = 7707212, upload-time = "2026-06-26T19:21:47.922Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

This is more or less actually for the frontend. Now, there is a new attr within the responses called `in_use`. Its job is to show that a tag is "in use" (i.e., used by a project or event), and if it's in use, then it can't be deleted until the projects or events associated with it are deleted or changed. Furthermore, when attempting to delete a tag, now it will detect whether a tag is attached to a project or event, and refuse to actually delete unless it's actually detached from the project or event. It'll also show you what project(s) or event(s) it's attached to.

> [!NOTE]
> Due to the async client overhaul in valkey-glide 2.5.0, previously using Unix Domain Socket and protobuf responses to using direct FFI calls, it broke our tests. Reverted back to 2.4.2 for the time being until I can track down the root cause

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
