### PR TITLE
Pin `valkey-glide` to v2.4.2 due to regression bug

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,7 +39,6 @@
       "automerge": true
     },
     {
-
       "matchManagers": [
         "github-actions"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
     "enabled": true,
     "automerge": true
   },
+  // valkey-glide v2.5.0 has a regression bug, due to their FFI rewrite from UDS
+  // Ignore it for now, as it will be pinned to v2.4.2 until this regression is fixed
+  // See: https://github.com/valkey-io/valkey-glide/pull/5637
+  "ignoreDeps": ["valkey-glide"],
   "packageRules": [
     {
       "matchManagers": [
@@ -35,7 +39,7 @@
       "automerge": true
     },
     {
-      
+
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
# Summary

valkey-glide v2.5.0 overhaulled their async Python client. Instead of using Unix Domain Sockets (UDS) and protobuf responses, now they are using direct FFI calls and OS pipes. This improves performance but literally breaks out test and app entirely. It got to the point where our tests were deadlocked for 6+ hours, and our integration tests stalled for hours as well. Due to this, some testing found out that it's a regression on their end, so pinning it to v2.4.2 until I can either hop on their discord server or file in a github issue about this.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [ ] All workflows pass with my new changes
- [ ] This PR does **not** address a duplicate issue or PR
