### PR TITLE
Explictly add `--frozen` to `uv run` invocations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       UV_NO_DEV: true
       UV_NO_DEFAULT_GROUPS: true
-      UV_FROZEN: true
 
     steps:
       - name: Checkout Repository
@@ -44,12 +43,12 @@ jobs:
 
       - name: Check typing
         run: |
-          uv run ty check src --error-on-warning
+          uv run --frozen ty check src --error-on-warning
 
       - name: Check codebase
         run: |
-          uv run ruff check src --exit-non-zero-on-fix
+          uv run --frozen ruff check src --exit-non-zero-on-fix
 
       - name: Check for formatting
         run: |
-          uv run ruff format src --check
+          uv run --frozen ruff format src --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
       TESTCONTAINER_DOCKER_NETWORK: kanae-testcontainers
       UV_NO_DEV: true
       UV_NO_DEFAULT_GROUPS: true
-      UV_FROZEN: true
 
     steps:
       - name: Checkout Repository
@@ -54,7 +53,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          uv run pytest
+          uv run --frozen pytest
 
   Integration:
     name: Integration


### PR DESCRIPTION
# Summary

Apparently sonarcloud is throwing a hissy fit.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
