### PR TITLE
Allow `Role.ADMIN` to bypass permission checks

### DIFF
--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -1278,7 +1278,7 @@ class UpgradeMemberRole(BaseModel, frozen=True):
 
 @router.put(
     "/projects/{project_id}/member/modify",
-    dependencies=[has_permissions(Project.own), has_role(Role.MANAGER)],
+    dependencies=[check_any(has_role(Role.MANAGER), has_permissions(Project.own))],
     include_in_schema=False,
     responses={200: {"model": DeleteResponse}},
 )

--- a/src/utils/checks.py
+++ b/src/utils/checks.py
@@ -288,7 +288,7 @@ def has_permissions[ContextT: CheckContext](
         msg = "has_permissions must contain more than one arguments"
         raise TypeError(msg)
 
-    async def pred(ctx: ContextT) -> Literal[True]:
+    async def pred(ctx: ContextT) -> bool:
         missing = [
             perm
             for perm in permissions

--- a/src/utils/checks.py
+++ b/src/utils/checks.py
@@ -288,7 +288,7 @@ def has_permissions[ContextT: CheckContext](
         msg = "has_permissions must contain more than one arguments"
         raise TypeError(msg)
 
-    async def pred(ctx: ContextT) -> bool:
+    async def pred(ctx: ContextT) -> Literal[True]:
         missing = [
             perm
             for perm in permissions

--- a/src/utils/checks.py
+++ b/src/utils/checks.py
@@ -271,6 +271,10 @@ def has_permissions[ContextT: CheckContext](
         TypeError: No permissions were supplied.
         MissingPermissions: Caller lacks the specified permissions
 
+    Note:
+        Members that hold `Role.ADMIN` pass unconditionally. An "admin" owns
+        all resources, as they are an admin of the site.
+
     Example:
         Require both edit and own on a project before allowing deletion::
 
@@ -299,6 +303,11 @@ def has_permissions[ContextT: CheckContext](
         ]
 
         if not missing:
+            return True
+
+        if await ctx.ory.check_permission(
+            "Role", Role.ADMIN, "member", ctx.session.identity.id
+        ):
             return True
 
         raise MissingPermissions(missing)

--- a/tests/integration/scenarios/16_project_create_denied_for_member.hurl
+++ b/tests/integration/scenarios/16_project_create_denied_for_member.hurl
@@ -51,7 +51,8 @@ Content-Type: application/json
 [{ "id": "{{MEMBER_ID}}" }]
 HTTP 403
 
-# Member role modify — Project.own AND Role.MANAGER required.
+# Member role modify — Role.MANAGER OR Project.own required. MEMBER has
+# neither.
 PUT {{KANAE_URL}}/projects/77777777-7777-4777-8777-777777777777/member/modify
 Content-Type: application/json
 { "id": "{{MEMBER_ID}}", "role": "lead" }

--- a/tests/integration/scenarios/23_manager_project_admin.hurl
+++ b/tests/integration/scenarios/23_manager_project_admin.hurl
@@ -1,15 +1,15 @@
 # Manager-side project administration journey: create → bulk-join
-# extra members → grant self Project.own (required by member/modify) →
-# promote a member to lead → flip the same member to "former" →
-# verify the role transitions surface in /projects/{id}.members.
+# extra members → grant self Project.own → promote a member to lead →
+# flip the same member to "former" → verify the role transitions surface
+# in /projects/{id}.members.
 #
 # Exercises three routes nothing else touches:
 #   POST /projects/{id}/bulk-join     (1/minute, this scenario owns it)
 #   PUT  /projects/{id}/member/modify (3/minute, this scenario owns it)
-#   `check_any(has_role(MANAGER), has_permissions(Project.own))` on
-#   bulk-join is satisfied via the MANAGER role from bootstrap, so we
-#   only need Keto Project.own for member/modify (which also checks
-#   Project.own AND Role.MANAGER).
+#   Both carry `check_any(has_role(MANAGER), has_permissions(Project.own))`,
+#   satisfied here by the MANAGER role from bootstrap. The explicit
+#   Project.own grant below is therefore redundant for authorization — it is
+#   kept so this scenario also covers the owner arm and the Keto write path.
 #
 # Pydantic 422s (malformed UUIDs, missing fields, bad literals) fire
 # BEFORE the route function and don't count against the limiters, so
@@ -119,7 +119,8 @@ body contains "{{MANAGER_ID}}"
 body contains "{{MEMBER_ID}}"
 body contains "{{LEADS_ID}}"
 
-# --- Project.own grant (member/modify requires it AND Role.MANAGER).
+# --- Project.own grant. member/modify already admits this session via the
+# MANAGER role; the grant exercises the owner arm and the Keto write path.
 PUT {{KETO_WRITE_URL}}/admin/relation-tuples
 Content-Type: application/json
 Accept: application/json

--- a/tests/integration/scenarios/25_media_api_and_filter_matrix.hurl
+++ b/tests/integration/scenarios/25_media_api_and_filter_matrix.hurl
@@ -208,14 +208,19 @@ jsonpath "$.session.identity.id" == "{{ADMIN_ID}}"
 # first thing that can fail.
 
 # Path-param malformed UUID — has_permissions(Project.view) reads the raw
-# path string as the Keto object id BEFORE FastAPI coerces it to uuid.UUID.
-# ADMIN holds Project:dddddddd-…/view but not Project:not-a-uuid/view, so
-# Keto answers "no" and the dependency returns 403 — the path-coercion 422
-# is never reached. (Routes that bypass Keto via has_role — bulk-join,
-# tested in scenario 23 — *do* surface path 422 because the role check is
-# project-id-agnostic.)
+# path string as the Keto object id BEFORE FastAPI coerces it to uuid.UUID,
+# and `_is_uuid` rejects "not-a-uuid" without ever asking Keto. For a
+# non-admin that surfaces as 403 (the permission is "missing"), but ADMIN
+# short-circuits the whole check, so the request proceeds to path coercion
+# and Pydantic answers 422 instead. Same as any other role-agnostic route
+# (bulk-join via has_role, scenario 23).
+#
+# So the status here is admin-specific: re-running this block as MEMBER
+# would yield 403, not 422.
 GET {{KANAE_URL}}/projects/not-a-uuid/media
-HTTP 403
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].type" contains "uuid_parsing"
 
 # upload: missing hash.
 POST {{KANAE_URL}}/projects/dddddddd-dddd-4ddd-8ddd-dddddddddddd/media/upload

--- a/tests/integration/scenarios/41_admin_bypasses_resource_permissions.hurl
+++ b/tests/integration/scenarios/41_admin_bypasses_resource_permissions.hurl
@@ -1,0 +1,187 @@
+# Regression: an ADMIN could not read the attendance of an event it did not
+# create. Event creation writes only `owners@creator` and
+# `editors@Role:leads#member` (routes/events.py), and project creation only
+# `owners@creator` and `editors@Role:manager#member` — so a global admin holds
+# NO relation tuple on any resource it did not personally create. Keto's OPL
+# cannot express "admins reach every object in a namespace" without a per-object
+# tuple, so `has_permissions` carries the bypass instead.
+#
+# This scenario proves both halves at once:
+#   1. Keto itself still says NO for the admin on the resource (direct check
+#      against KETO_READ_URL returns 403 / allowed:false).
+#   2. Kanae says YES anyway, because of the bypass in has_permissions.
+#
+# LEADS/MANAGER create the resources so that ADMIN is genuinely un-tupled;
+# creating them as ADMIN would grant `owners` and prove nothing.
+#
+# Note: `check_permission` is @cached_method for 60s keyed on
+# `(namespace, object, relation, subject_id)`. Every resource here is created
+# fresh inside this scenario, so no stale entry can pre-exist.
+
+# --- LEADS creates the event (and auto-owns it).
+
+GET {{KRATOS_URL}}/self-service/login/browser
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{LEADS_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{LEADS_ID}}"
+
+POST {{KANAE_URL}}/events/create
+Content-Type: application/json
+{
+  "id": "41414141-4141-4141-8141-414141414141",
+  "name": "scenario41-admin-bypass",
+  "description": "created by leads, read by admin",
+  "start_at": "2099-06-01T00:00:00Z",
+  "end_at":   "2099-06-01T03:00:00Z",
+  "location": "Online",
+  "type": "general",
+  "timezone": "UTC",
+  "creator_id": "{{LEADS_ID}}"
+}
+HTTP 200
+[Captures]
+event_id: jsonpath "$.id"
+
+# --- MANAGER creates the project (and auto-owns it).
+
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{MANAGER_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{MANAGER_ID}}"
+
+POST {{KANAE_URL}}/projects/create
+Content-Type: application/json
+{
+  "name": "scenario41-admin-bypass",
+  "description": "created by manager, edited by admin",
+  "link": "https://example.test/scenario41",
+  "type": "sig_arch",
+  "active": true,
+  "founded_at": "2024-01-01T00:00:00Z"
+}
+HTTP 200
+[Captures]
+project_id: jsonpath "$.id"
+
+# --- Keto's own view: the ADMIN holds nothing on either resource.
+# The check endpoint answers 403 (not 200) when the relation does not hold.
+
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Event&object={{event_id}}&relation=edit&subject_id={{ADMIN_ID}}
+HTTP 403
+[Asserts]
+jsonpath "$.allowed" == false
+
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Project&object={{project_id}}&relation=edit&subject_id={{ADMIN_ID}}
+HTTP 403
+[Asserts]
+jsonpath "$.allowed" == false
+
+# Sanity: the admin DOES hold the global role the bypass keys off.
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=admin&relation=member&subject_id={{ADMIN_ID}}
+HTTP 200
+[Asserts]
+jsonpath "$.allowed" == true
+
+# --- Switch to ADMIN. Kanae admits it anyway.
+
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{ADMIN_ID}}"
+
+# The exact route from the bug report: has_permissions(Event.edit).
+GET {{KANAE_URL}}/events/{{event_id}}/attendance?page=1&size=100
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.total" == 0
+
+# Also gated on Event.edit.
+GET {{KANAE_URL}}/events/{{event_id}}/attendance-code
+HTTP 200
+[Asserts]
+jsonpath "$.code" isString
+
+PUT {{KANAE_URL}}/events/{{event_id}}
+Content-Type: application/json
+{ "name": "scenario41-renamed-by-admin", "description": "admin edit", "location": "Online" }
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "scenario41-renamed-by-admin"
+
+# Project side: has_permissions(Project.edit).
+PUT {{KANAE_URL}}/projects/{{project_id}}
+Content-Type: application/json
+{ "name": "scenario41-renamed-by-admin", "description": "admin edit", "link": "https://example.test/scenario41" }
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "scenario41-renamed-by-admin"
+
+# check_any(has_role(MANAGER), has_permissions(Project.edit)) — the admin
+# passes via the inner has_permissions, not the role arm.
+GET {{KANAE_URL}}/projects/{{project_id}}/invites?status=pending
+HTTP 200
+
+# check_any(has_role(MANAGER), has_permissions(Project.own)) — ADMIN matches
+# neither arm directly; it gets in via the bypass inside has_permissions.
+PUT {{KANAE_URL}}/projects/{{project_id}}/member/modify
+Content-Type: application/json
+{ "id": "{{MANAGER_ID}}", "role": "former" }
+HTTP 200
+
+# --- The bypass is Role.ADMIN only: a plain MEMBER is still refused.
+
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{MEMBER_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{MEMBER_ID}}"
+
+GET {{KANAE_URL}}/events/{{event_id}}/attendance
+HTTP 403
+[Asserts]
+jsonpath "$.result" == "error"
+
+PUT {{KANAE_URL}}/projects/{{project_id}}/member/modify
+Content-Type: application/json
+{ "id": "{{MEMBER_ID}}", "role": "lead" }
+HTTP 403

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1427,3 +1427,95 @@ async def test_list_events_name_combines_with_after(
     )
     assert response.status_code == 200
     assert {e["name"] for e in response.json()["data"]} == {"workshop-new"}
+
+
+# ──────────────────────────────────────────────────────────────────
+# Admin bypass on has_permissions, no per-resource Keto grant needed
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_admin_lists_attendance_without_event_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    # Regression: admins used to 403 here because event creation only writes
+    # owners@creator and editors@Role:leads#member, so a global admin held no
+    # tuple on the event at all.
+    fake_ory.login_as(Role.ADMIN)
+    event_id = await _insert_event(kanae.pool, name="admin-roster")
+    attendee = await _insert_member(
+        kanae.pool, member_id=uuid.uuid4(), name="Attendee", email="a@test.local"
+    )
+    await _link_event_member(
+        kanae.pool, event_id=event_id, member_id=attendee, planned=True, attended=True
+    )
+
+    response = await client.client.get(f"/events/{event_id}/attendance")
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+
+
+async def test_admin_edits_event_without_event_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    event_id = await _insert_event(kanae.pool, name="admin-editable")
+
+    response = await client.client.put(
+        f"/events/{event_id}", json=_valid_event_payload(name="renamed-by-admin")
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "renamed-by-admin"
+
+
+async def test_admin_deletes_event_without_own_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    event_id = await _insert_event(kanae.pool, name="admin-deletable")
+
+    response = await client.client.delete(f"/events/{event_id}")
+    assert response.status_code == 200
+
+    remaining = await kanae.pool.fetchval(
+        "SELECT count(*) FROM events WHERE id = $1", event_id
+    )
+    assert remaining == 0
+
+
+async def test_admin_reads_attendance_code_without_event_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    event_id = await _insert_event(kanae.pool, name="admin-code")
+    await kanae.pool.execute(
+        "INSERT INTO event_attendance_codes (event_id, attendance_hash, attendance_code) "
+        "VALUES ($1, $2, $3)",
+        event_id,
+        "dummyhash",
+        "ADMIN123TRAILING",
+    )
+
+    response = await client.client.get(f"/events/{event_id}/attendance-code")
+    assert response.status_code == 200
+    assert response.json()["code"] == "ADMIN123"
+
+
+@pytest.mark.parametrize("role", [Role.MANAGER, Role.LEADS, Role.ROOT])
+async def test_non_admin_roles_do_not_bypass_event_permissions(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae, role: Role
+) -> None:
+    fake_ory.login_as(role)
+    event_id = await _insert_event(kanae.pool, name=f"no-bypass-{role.value}")
+
+    response = await client.client.get(f"/events/{event_id}/attendance")
+    assert response.status_code == 403
+
+
+async def test_roleless_member_still_denied_event_attendance(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as()
+    event_id = await _insert_event(kanae.pool, name="still-denied")
+
+    response = await client.client.get(f"/events/{event_id}/attendance")
+    assert response.status_code == 403

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -853,7 +853,7 @@ async def test_leave_project_removes_membership(
 
 
 # ──────────────────────────────────────────────────────────────────
-# Modify member role, undocumented, Project.own + manager, 3 per minute
+# Modify member role, undocumented, manager OR Project.own, 3 per minute
 # ──────────────────────────────────────────────────────────────────
 
 
@@ -865,17 +865,114 @@ async def test_modify_member_requires_session(client: KanaeTestClient) -> None:
     assert response.status_code == 401
 
 
-async def test_modify_member_rejects_without_manager_role(
+async def test_modify_member_rejects_without_manager_or_own(
     client: KanaeTestClient, fake_ory: FakeOryClient
 ) -> None:
-    identity_id = fake_ory.login_as()
-    target_project = uuid.uuid4()
-    await fake_ory.grant("Project", str(target_project), "own", identity_id)
+    fake_ory.login_as()
     response = await client.client.put(
-        f"/projects/{target_project}/member/modify",
+        f"/projects/{uuid.uuid4()}/member/modify",
         json={"id": str(uuid.uuid4()), "role": "lead"},
     )
     assert response.status_code == 403
+
+
+@pytest.mark.parametrize("role", [Role.LEADS, Role.ROOT])
+async def test_modify_member_rejects_unrelated_roles_without_own(
+    client: KanaeTestClient, fake_ory: FakeOryClient, role: Role
+) -> None:
+    # Only MANAGER (or ADMIN, via the has_permissions bypass) clears this
+    # without Project.own.
+    fake_ory.login_as(role)
+    response = await client.client.put(
+        f"/projects/{uuid.uuid4()}/member/modify",
+        json={"id": str(uuid.uuid4()), "role": "lead"},
+    )
+    assert response.status_code == 403
+
+
+async def test_modify_member_allows_manager_without_own(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    member_to_promote = uuid.uuid4()
+    project_id = await _insert_project(kanae.pool, name="manager-no-own")
+
+    await _insert_member(kanae.pool, member_id=member_to_promote)
+    await _link_project_member(
+        kanae.pool,
+        project_id=project_id,
+        member_id=member_to_promote,
+        role="member",
+    )
+
+    response = await client.client.put(
+        f"/projects/{project_id}/member/modify",
+        json={"id": str(member_to_promote), "role": "lead"},
+    )
+    assert response.status_code == 200
+    assert (
+        await _membership_role(
+            kanae.pool, project_id=project_id, member_id=member_to_promote
+        )
+        == "lead"
+    )
+
+
+async def test_modify_member_allows_owner_without_manager_role(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    member_to_promote = uuid.uuid4()
+    project_id = await _insert_project(kanae.pool, name="owner-no-manager")
+    await fake_ory.grant("Project", str(project_id), "own", identity_id)
+
+    await _insert_member(kanae.pool, member_id=member_to_promote)
+    await _link_project_member(
+        kanae.pool,
+        project_id=project_id,
+        member_id=member_to_promote,
+        role="member",
+    )
+
+    response = await client.client.put(
+        f"/projects/{project_id}/member/modify",
+        json={"id": str(member_to_promote), "role": "lead"},
+    )
+    assert response.status_code == 200
+    assert (
+        await _membership_role(
+            kanae.pool, project_id=project_id, member_id=member_to_promote
+        )
+        == "lead"
+    )
+
+
+async def test_modify_member_allows_admin_without_own(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    member_to_promote = uuid.uuid4()
+    project_id = await _insert_project(kanae.pool, name="admin-modifiable")
+
+    await _insert_member(kanae.pool, member_id=member_to_promote)
+    await _link_project_member(
+        kanae.pool,
+        project_id=project_id,
+        member_id=member_to_promote,
+        role="member",
+    )
+
+    response = await client.client.put(
+        f"/projects/{project_id}/member/modify",
+        json={"id": str(member_to_promote), "role": "lead"},
+    )
+    assert response.status_code == 200
+    assert (
+        await _membership_role(
+            kanae.pool, project_id=project_id, member_id=member_to_promote
+        )
+        == "lead"
+    )
 
 
 async def test_modify_member_promotes_existing_membership(
@@ -2603,3 +2700,92 @@ async def test_list_project_invites_enforces_10_per_minute(
 
         blocked = await client.client.get(f"/projects/{project_id}/invites")
         assert blocked.status_code == 429
+
+
+# ──────────────────────────────────────────────────────────────────
+# Admin bypass on has_permissions, no per-resource Keto grant needed
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_admin_edits_project_without_project_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    project_id = await _insert_project(kanae.pool, name="admin-editable")
+
+    response = await client.client.put(
+        f"/projects/{project_id}",
+        json={
+            "name": "renamed-by-admin",
+            "description": "new-desc",
+            "link": "https://new.test",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "renamed-by-admin"
+
+
+async def test_admin_deletes_project_without_own_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    project_id = await _insert_project(kanae.pool, name="admin-deletable")
+
+    response = await client.client.delete(f"/projects/{project_id}")
+    assert response.status_code == 200
+
+    remaining = await kanae.pool.fetchval(
+        "SELECT count(*) FROM projects WHERE id = $1", project_id
+    )
+    assert remaining == 0
+
+
+async def test_admin_lists_invites_without_project_grant(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    project_id = await _insert_project(kanae.pool, name="admin-invites")
+
+    response = await client.client.get(f"/projects/{project_id}/invites")
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("role", [Role.MANAGER, Role.LEADS, Role.ROOT])
+async def test_non_admin_roles_do_not_bypass_project_permissions(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae, role: Role
+) -> None:
+    fake_ory.login_as(role)
+    project_id = await _insert_project(kanae.pool, name=f"no-bypass-{role.value}")
+
+    response = await client.client.delete(f"/projects/{project_id}")
+    assert response.status_code == 403
+
+
+async def test_roleless_member_still_denied_project_edit(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="still-denied")
+
+    response = await client.client.put(
+        f"/projects/{project_id}",
+        json={"name": "nope", "description": "d", "link": "https://x.test"},
+    )
+    assert response.status_code == 403
+
+
+async def test_admin_malformed_project_id_falls_through_to_422(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    response = await client.client.get("/projects/not-a-uuid/media")
+    assert response.status_code == 422
+    assert "uuid_parsing" in {e["type"] for e in response.json()["errors"]}
+
+
+async def test_non_admin_malformed_project_id_still_403(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as()
+    response = await client.client.get("/projects/not-a-uuid/media")
+    assert response.status_code == 403


### PR DESCRIPTION
# Summary

Previously, `Role.ADMIN` holders did not have permission on any of the events and projects management. The intended outcome is that an admin who holds `Role.ADMIN`, is really site admins so they need the ability to manage events and projects.

Without this, the frontend literally breaks as every single request ends up being HTTP 403 errors

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
