### PR TITLE
Add `/projects/invites` route

### DIFF
--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -192,6 +192,71 @@ async def list_projects(
 
 
 @router.get(
+    "/projects/invites",
+    dependencies=[check_any(has_role(Role.MANAGER), has_role(Role.ADMIN))],
+    responses={
+        200: {"model": list[ProjectInvite]},
+        403: {"model": ForbiddenResponse},
+    },
+)
+@router.limiter.limit("10/minute")
+async def list_all_project_invites(
+    request: RouteRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+    *,
+    status: Optional[
+        Literal["pending", "accepted", "declined", "revoked", "expired"]
+    ] = None,
+    kind: Optional[Literal["invite", "request"]] = None,
+) -> list[ProjectInvite]:
+    """View project invites across every project, meant for managers to view"""
+    args: list = []
+    constraint = ""
+
+    if status and kind:
+        constraint = "WHERE invites.status = $1 AND invites.kind = $2"
+        args.extend((status, kind))
+    elif status or kind:
+        column = "status" if status else "kind"
+        constraint = f"WHERE invites.{column} = $1"
+        args.append(status or kind)
+
+    query = f"""
+    WITH invites AS (
+        SELECT
+            project_invites.id,
+            project_invites.project_id,
+            jsonb_build_object('id', members.id, 'name', members.name) AS member,
+            project_invites.invited_by,
+            project_invites.kind,
+            CASE
+                WHEN project_invites.status = 'pending'
+                     AND project_invites.expires_at IS NOT NULL
+                     AND project_invites.expires_at <= NOW()
+                THEN 'expired'
+                ELSE project_invites.status
+            END AS status,
+            project_invites.message,
+            project_invites.created_at,
+            project_invites.responded_at,
+            project_invites.expires_at
+        FROM project_invites
+        INNER JOIN members ON members.id = project_invites.member_id
+    )
+    SELECT
+        invites.id, invites.project_id, invites.member,
+        invites.invited_by, invites.kind, invites.status,
+        invites.message, invites.created_at,
+        invites.responded_at, invites.expires_at
+    FROM invites
+    {constraint}
+    ORDER BY invites.created_at DESC
+    """
+    rows = await request.app.pool.fetch(query, *args)
+    return [ProjectInvite(**dict(row)) for row in rows]
+
+
+@router.get(
     "/projects/{project_id}",
     responses={200: {"model": FullProjects}, 404: {"model": NotFoundResponse}},
 )

--- a/tests/integration/scenarios/42_manage_invites_across_projects.hurl
+++ b/tests/integration/scenarios/42_manage_invites_across_projects.hurl
@@ -1,0 +1,186 @@
+# The dashboard's manage/projects page loads its invite tab from
+# GET /projects/invites with `?status=pending` — one cross-project read,
+# no project id anywhere. This scenario walks that exact call plus the
+# gate around it.
+#
+# Two things separate this route from /projects/{id}/invites:
+#   - The gate is `check_any(has_role(MANAGER), has_role(ADMIN))`.
+#     `Project.edit` cannot appear here: has_permissions resolves the
+#     object id out of request.path_params["project_id"], and this path
+#     has none. So LEADS — a lead by Keto grant rather than by role — is
+#     refused here even though it reads the per-project route freely.
+#   - The rows span every project, not one. Proven below by comparing
+#     the global count against the count for a single project taken
+#     out of the same response.
+#
+# A 422 with `uuid_parsing` on any call here means the route ended up
+# registered after GET /projects/{project_id} and the parameterized
+# path swallowed the literal one (Starlette matches in registration
+# order).
+#
+# Reads only — nothing is created, so this scenario spends nothing from
+# the 15/minute /projects/create budget. It does assume the earlier
+# invite scenarios (34-38) have run and left invites on several
+# projects, which is what the cross-project assertions rest on; the
+# suite is run as one glob (tests/integration/init.sh).
+# Handler-reached calls: 5 of this route's 10/minute (4 as MANAGER, 1 as
+# ADMIN) plus one per-project read. The 401/403s are refused by the
+# dependency before the limiter and cost nothing.
+
+# --- No session at all: 401, not 422 and not 403. ---
+GET {{KANAE_URL}}/projects/invites?status=pending
+HTTP 401
+[Asserts]
+header "content-type" startsWith "application/json"
+jsonpath "$.result" == "error"
+
+# --- MANAGER: the page load. ---
+GET {{KRATOS_URL}}/self-service/login/browser
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{MANAGER_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{MANAGER_ID}}"
+
+# Byte-for-byte what manageInvitesQueryOptions issues on mount.
+GET {{KANAE_URL}}/projects/invites?status=pending
+HTTP 200
+[Asserts]
+header "content-type" startsWith "application/json"
+jsonpath "$" isCollection
+# the filter is applied server-side — no other status may come back
+jsonpath "$[*].status" not contains "accepted"
+jsonpath "$[*].status" not contains "declined"
+jsonpath "$[*].status" not contains "revoked"
+jsonpath "$[*].status" not contains "expired"
+
+# Unfiltered, and the cross-project claim. `total` is every invite in
+# the system; `first_project` is the project of the newest one.
+GET {{KANAE_URL}}/projects/invites
+HTTP 200
+[Captures]
+first_project: jsonpath "$[0].project_id"
+total: jsonpath "$" count
+[Asserts]
+jsonpath "$" isCollection
+jsonpath "$" count > 1
+# the shape the page renders each row from
+jsonpath "$[0].id" isString
+jsonpath "$[0].project_id" isString
+jsonpath "$[0].member.id" isString
+jsonpath "$[0].member.name" isString
+jsonpath "$[0].kind" matches "invite|request"
+jsonpath "$[0].status" matches "pending|accepted|declined|revoked|expired"
+jsonpath "$[0].created_at" isString
+jsonpath "$[*].project_id" contains "{{first_project}}"
+
+# Same manager, same invite model, scoped to one project: strictly
+# fewer rows. That gap is the whole point of the new route — the rows
+# it returned above belong to projects this call cannot see.
+GET {{KANAE_URL}}/projects/{{first_project}}/invites
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+jsonpath "$" count < {{total}}
+
+# kind filter, the one-placeholder branch of the constraint.
+GET {{KANAE_URL}}/projects/invites?kind=request
+HTTP 200
+[Asserts]
+jsonpath "$[*].kind" not contains "invite"
+
+# Both filters set, the two-placeholder branch.
+GET {{KANAE_URL}}/projects/invites?status=pending&kind=invite
+HTTP 200
+[Asserts]
+jsonpath "$[*].kind" not contains "request"
+jsonpath "$[*].status" not contains "accepted"
+jsonpath "$[*].status" not contains "declined"
+jsonpath "$[*].status" not contains "revoked"
+jsonpath "$[*].status" not contains "expired"
+
+# --- ADMIN: admitted by the second arm of the check. ---
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{ADMIN_ID}}"
+
+# Roles are flat (scripts/seed/init.sh grants one tuple per member), so
+# the admin holds no manager role...
+GET {{KETO_READ_URL}}/relation-tuples/check?namespace=Role&object=manager&relation=member&subject_id={{ADMIN_ID}}
+HTTP 403
+[Asserts]
+jsonpath "$.allowed" == false
+
+# ...and there is no resource in this path for the has_permissions
+# bypass to key off. This 200 comes from has_role(ADMIN) alone.
+GET {{KANAE_URL}}/projects/invites?status=pending
+HTTP 200
+[Asserts]
+jsonpath "$" isCollection
+
+# --- LEADS: a lead by Keto grant, refused here. ---
+# Scenario 37 grants LEADS Project.edit on its project, which opens
+# GET /projects/{id}/invites there. This route has no such arm.
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{LEADS_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{LEADS_ID}}"
+
+GET {{KANAE_URL}}/projects/invites?status=pending
+HTTP 403
+[Asserts]
+jsonpath "$.result" == "error"
+
+# --- MEMBER: no roles at all. ---
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{MEMBER_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{MEMBER_ID}}"
+
+GET {{KANAE_URL}}/projects/invites
+HTTP 403
+[Asserts]
+jsonpath "$.result" == "error"
+
+# Query params don't change the answer — the gate runs before them.
+GET {{KANAE_URL}}/projects/invites?status=pending&kind=invite
+HTTP 403

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -2601,6 +2601,205 @@ async def test_list_project_invites_isolated_by_project(
 
 
 # ──────────────────────────────────────────────────────────────────
+# List invites across every project (dashboard view), manager OR
+# admin, 10/min. No project in the path, so `Project.edit` has nothing
+# to scope to - the gate is roles only.
+# ──────────────────────────────────────────────────────────────────
+
+
+async def test_list_all_project_invites_requires_session(
+    client: KanaeTestClient,
+) -> None:
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 401
+
+
+async def test_list_all_project_invites_rejects_plain_member(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as()
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 403
+
+
+async def test_list_all_project_invites_rejects_project_editor(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="editor-scoped")
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 403
+
+
+async def test_list_all_project_invites_spans_projects(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    first_project = await _insert_project(kanae.pool, name="all-first")
+    second_project = await _insert_project(kanae.pool, name="all-second")
+    first_member = uuid.uuid4()
+    second_member = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=first_member)
+    await _insert_member(kanae.pool, member_id=second_member)
+    invite_a = await _insert_invite(
+        kanae.pool, project_id=first_project, member_id=first_member, kind="invite"
+    )
+    invite_b = await _insert_invite(
+        kanae.pool,
+        project_id=second_project,
+        member_id=second_member,
+        invited_by=second_member,
+        kind="request",
+    )
+
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert {row["id"] for row in body} == {str(invite_a), str(invite_b)}
+    assert {row["project_id"] for row in body} == {
+        str(first_project),
+        str(second_project),
+    }
+
+
+async def test_list_all_project_invites_allows_admin(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.ADMIN)
+    project_id = await _insert_project(kanae.pool, name="admin-view")
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+    invite_id = await _insert_invite(
+        kanae.pool, project_id=project_id, member_id=target, kind="invite"
+    )
+
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert [row["id"] for row in body] == [str(invite_id)]
+
+
+async def test_list_all_project_invites_filters_by_status(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    first_project = await _insert_project(kanae.pool, name="all-status-first")
+    second_project = await _insert_project(kanae.pool, name="all-status-second")
+    pending_member = uuid.uuid4()
+    declined_member = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=pending_member)
+    await _insert_member(kanae.pool, member_id=declined_member)
+    pending = await _insert_invite(
+        kanae.pool, project_id=first_project, member_id=pending_member, kind="invite"
+    )
+    await _insert_invite(
+        kanae.pool,
+        project_id=second_project,
+        member_id=declined_member,
+        kind="invite",
+        status="declined",
+    )
+
+    response = await client.client.get(
+        "/projects/invites", params={"status": "pending"}
+    )
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert [row["id"] for row in body] == [str(pending)]
+
+
+async def test_list_all_project_invites_filters_by_kind(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    first_project = await _insert_project(kanae.pool, name="all-kind-first")
+    second_project = await _insert_project(kanae.pool, name="all-kind-second")
+    invited = uuid.uuid4()
+    requested = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=invited)
+    await _insert_member(kanae.pool, member_id=requested)
+    await _insert_invite(
+        kanae.pool, project_id=first_project, member_id=invited, kind="invite"
+    )
+    request_id = await _insert_invite(
+        kanae.pool,
+        project_id=second_project,
+        member_id=requested,
+        invited_by=requested,
+        kind="request",
+    )
+
+    response = await client.client.get("/projects/invites", params={"kind": "request"})
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert [row["id"] for row in body] == [str(request_id)]
+
+
+async def test_list_all_project_invites_filters_by_status_and_kind(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    first_project = await _insert_project(kanae.pool, name="all-both-first")
+    second_project = await _insert_project(kanae.pool, name="all-both-second")
+    wanted_member = uuid.uuid4()
+    other_member = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=wanted_member)
+    await _insert_member(kanae.pool, member_id=other_member)
+    wanted = await _insert_invite(
+        kanae.pool,
+        project_id=first_project,
+        member_id=wanted_member,
+        invited_by=wanted_member,
+        kind="request",
+    )
+    # right kind, wrong status
+    await _insert_invite(
+        kanae.pool,
+        project_id=second_project,
+        member_id=other_member,
+        invited_by=other_member,
+        kind="request",
+        status="accepted",
+    )
+    # right status, wrong kind
+    await _insert_invite(
+        kanae.pool, project_id=second_project, member_id=other_member, kind="invite"
+    )
+
+    response = await client.client.get(
+        "/projects/invites", params={"status": "pending", "kind": "request"}
+    )
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    assert [row["id"] for row in body] == [str(wanted)]
+
+
+async def test_list_all_project_invites_lazily_marks_expired(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+    project_id = await _insert_project(kanae.pool, name="all-lazy-expire")
+    target = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=target)
+    invite_id = await _insert_invite(
+        kanae.pool,
+        project_id=project_id,
+        member_id=target,
+        kind="invite",
+        expires_at=_past(),
+    )
+
+    response = await client.client.get("/projects/invites")
+    assert response.status_code == 200
+    body: list[dict[str, Any]] = response.json()
+    row = next(r for r in body if r["id"] == str(invite_id))
+    assert row["status"] == "expired"
+    assert await _invite_status(kanae.pool, invite_id) == "pending"
+
+
+# ──────────────────────────────────────────────────────────────────
 # Invite-system rate limits
 # ──────────────────────────────────────────────────────────────────
 
@@ -2699,6 +2898,20 @@ async def test_list_project_invites_enforces_10_per_minute(
             assert response.status_code == 200
 
         blocked = await client.client.get(f"/projects/{project_id}/invites")
+        assert blocked.status_code == 429
+
+
+async def test_list_all_project_invites_enforces_10_per_minute(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    fake_ory.login_as(Role.MANAGER)
+
+    with hiro.Timeline().freeze():
+        for _ in range(10):
+            response = await client.client.get("/projects/invites")
+            assert response.status_code == 200
+
+        blocked = await client.client.get("/projects/invites")
         assert blocked.status_code == 429
 
 


### PR DESCRIPTION
# Summary

This is for listing all invites when loading up the `dashboard/manage/projects.tsx` page. We could do a whole bunch of for loops but this is better.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
