### PR TITLE
Add thumbnail creation endpoints

### DIFF
--- a/scripts/test-images.sh
+++ b/scripts/test-images.sh
@@ -80,6 +80,10 @@ RST=$'\033[0m'
 
 H_CONTENT_TYPE="Content-Type: application/json"
 JQ_HASH='.hash // empty'
+JQ_URL='.url // empty'
+
+# curl --write-out format selecting just the response status.
+CURL_HTTP_CODE='%{http_code}'
 
 step() {
 	local msg="$1"
@@ -98,6 +102,12 @@ fail() {
 	printf "${RED}✗${RST} %s\n" "$msg" >&2
 	exit 1
 }
+# One indented continuation line, e.g. a URL printed under its label. A helper
+# rather than a format-string constant: `printf "$FMT"` trips SC2059.
+detail() {
+	local msg="$1"
+	printf '    %s\n' "$msg"
+}
 
 require() {
 	local cmd="$1"
@@ -109,7 +119,7 @@ assert_http() {
 	local expected="$1" method="$2" url="$3"
 	shift 3
 	local actual
-	actual="$(curl -s -o /dev/null -w '%{http_code}' -X "$method" "$url" "$@")"
+	actual="$(curl -s -o /dev/null -w "$CURL_HTTP_CODE" -X "$method" "$url" "$@")"
 	if [[ "$actual" != "$expected" ]]; then
 		fail "expected HTTP $expected from $method $url, got $actual"
 	fi
@@ -288,11 +298,11 @@ upload_single() {
 	fi
 
 	local url
-	url=$(jq -r '.url // empty' <<<"$upload_resp")
+	url=$(jq -r "$JQ_URL" <<<"$upload_resp")
 	[[ -n "$url" ]] || fail "no presigned url in upload response: $upload_resp"
 
 	local put_code
-	put_code=$(curl -s -o /dev/null -w '%{http_code}' \
+	put_code=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE" \
 		-X PUT "$url" \
 		-H "Content-Type: $content_type" \
 		--data-binary "@$file")
@@ -582,16 +592,16 @@ THUMB_OBJ=$(jq -c '.thumbnail' <<<"$PROJ_RESP")
 	|| fail "thumbnail missing from project response: $PROJ_RESP"
 
 THUMB_HASH=$(jq -r "$JQ_HASH" <<<"$THUMB_OBJ")
-THUMB_URL=$(jq -r '.url // empty' <<<"$THUMB_OBJ")
+THUMB_URL=$(jq -r "$JQ_URL" <<<"$THUMB_OBJ")
 [[ -n "$THUMB_HASH" && -n "$THUMB_URL" ]] \
 	|| fail "thumbnail object missing hash or url: $THUMB_OBJ"
 ok "thumbnail.hash = $THUMB_HASH"
-printf "    %s\n" "$THUMB_URL"
+detail "$THUMB_URL"
 
 # ── 22. thumbnail URL is anonymously reachable and returns webp ───────────────
 step "22. GET <thumbnail_url> returns 200 + image/webp"
 
-THUMB_CHECK=$(curl -s -o /dev/null -w '%{http_code} %{content_type}' "$THUMB_URL")
+THUMB_CHECK=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE %{content_type}" "$THUMB_URL")
 THUMB_STATUS="${THUMB_CHECK%% *}"
 THUMB_TYPE="${THUMB_CHECK#* }"
 if [[ "$THUMB_STATUS" == "200" && "$THUMB_TYPE" == image/webp* ]]; then
@@ -683,7 +693,7 @@ POST_DELETE_THUMB=$(jq -r '.thumbnail' <<<"$POST_DELETE")
 	|| fail "thumbnail not cleared from project: $POST_DELETE_THUMB"
 ok "project.thumbnail is null after DELETE"
 
-DEL_CHECK=$(curl -s -o /dev/null -w '%{http_code}' "$CURRENT_URL")
+DEL_CHECK=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE" "$CURRENT_URL")
 if [[ "$DEL_CHECK" == "404" ]]; then
 	ok "thumbnail URL now returns 404 anonymously"
 else
@@ -729,11 +739,11 @@ thumbnail_flow() {
 		mode="fresh"
 
 		local url put_code
-		url=$(jq -r '.url // empty' <<<"$upload_resp")
+		url=$(jq -r "$JQ_URL" <<<"$upload_resp")
 		[[ -n "$url" ]] \
 			|| fail "no presigned url in thumbnail upload response: $upload_resp"
 
-		put_code=$(curl -s -o /dev/null -w '%{http_code}' \
+		put_code=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE" \
 			-X PUT "$url" \
 			-H "Content-Type: $content_type" \
 			--data-binary "@$file")
@@ -747,7 +757,7 @@ thumbnail_flow() {
 		-H "$H_CONTENT_TYPE" \
 		-d "$body")
 	thumb_hash=$(jq -r "$JQ_HASH" <<<"$commit_resp")
-	thumb_url=$(jq -r '.url // empty' <<<"$commit_resp")
+	thumb_url=$(jq -r "$JQ_URL" <<<"$commit_resp")
 	[[ -n "$thumb_hash" && -n "$thumb_url" ]] \
 		|| fail "thumbnail commit failed: $commit_resp"
 
@@ -781,7 +791,7 @@ read -r STAGED_MODE STAGED_HASH STAGED_URL <<<"$FLOW_RESULT"
 [[ "$STAGED_MODE" == "fresh" ]] \
 	|| warn "expected the presign branch after the reap, took '$STAGED_MODE' instead"
 ok "$STAGED_MODE flow committed thumbnail $STAGED_HASH"
-printf "    %s\n" "$STAGED_URL"
+detail "$STAGED_URL"
 
 # ── 31. the committed thumbnail is the project's thumbnail ────────────────────
 step "31. GET /projects/{id} reflects the committed thumbnail"
@@ -799,7 +809,7 @@ jq -e --arg h "$THUMB_SRC_HASH" 'any(.[]; .hash == $h)' <<<"$STAGED_LIST" >/dev/
 	|| fail "commit did not re-link the source media: $STAGED_LIST"
 ok "commit re-linked the source into project_media"
 
-STAGED_CHECK=$(curl -s -o /dev/null -w '%{http_code} %{content_type}' "$STAGED_URL")
+STAGED_CHECK=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE %{content_type}" "$STAGED_URL")
 STAGED_STATUS="${STAGED_CHECK%% *}"
 STAGED_TYPE="${STAGED_CHECK#* }"
 if [[ "$STAGED_STATUS" == "200" && "$STAGED_TYPE" == image/webp* ]]; then
@@ -893,7 +903,7 @@ read -r EVENT_MODE EVENT_THUMB_HASH EVENT_THUMB_URL <<<"$EVENT_FLOW"
 [[ "$EVENT_MODE" == "dedup" ]] \
 	|| warn "expected the dedup branch for a known hash, took '$EVENT_MODE' instead"
 ok "$EVENT_MODE flow committed thumbnail $EVENT_THUMB_HASH"
-printf "    %s\n" "$EVENT_THUMB_URL"
+detail "$EVENT_THUMB_URL"
 
 # Same source bytes as the project thumbnail, so the processed WebP is
 # content-identical and lands on the same hash.
@@ -944,5 +954,5 @@ printf "  project id:  %s\n" "$PROJECT_ID"
 printf "  event id:    %s\n" "$EVENT_ID"
 printf "  hashes:\n"
 for h in "${HASHES[@]}"; do
-	printf "    %s\n" "$h"
+	detail "$h"
 done

--- a/scripts/test-images.sh
+++ b/scripts/test-images.sh
@@ -8,10 +8,19 @@
 #   PUT    /projects/{id}/media/positions (reorder)
 #   DELETE /projects/{id}/media/{hash}    (detach)
 #
+# and for the thumbnail staging flow on both resources:
+#   POST   /projects/{id}/thumbnail/upload + /commit
+#   POST   /events/{id}/thumbnail/upload   + /commit
+#
 # Reuses the registration + role + project setup from test-flow.sh and then
 # pushes every file in ./test-images through the full upload flow — single
 # PUT for files ≤ 16 MB, multipart for anything larger — plus a set of
 # negative cases for the validation guards.
+#
+# The thumbnail half (steps 29+) covers both entry branches: the project run
+# starts from a reaped hash and therefore presigns + PUTs, while the event run
+# reuses that now-known hash and takes the dedup branch. Both converge on
+# commit, which is where the pyvips encode and the thumbnail_hash swap happen.
 #
 # Run after `docker compose up -d`. Garage must be initialized too
 # (`mise run garage:setup`). Requires: curl, jq, docker, uvx (mise),
@@ -155,6 +164,17 @@ done < <(find "$IMAGES_DIR" -maxdepth 1 -type f \
 
 [[ ${#MEDIA_FILES[@]} -ge 1 ]] || fail "no supported media files in $IMAGES_DIR"
 ok "found ${#MEDIA_FILES[@]} media files"
+
+# /media/upload is billed per file, and steps 8-12 spend 5 more on the same
+# key. The limiter keys on the request path (key_style="url") and each run
+# creates a fresh project, so nothing carries over between runs — but a large
+# enough directory exhausts the budget inside a single run, which surfaces as a
+# confusing 429 on whichever negative case happens to land last.
+UPLOAD_RATE_LIMIT=60 # mirrors @router.limiter.limit on upload_media
+if ((${#MEDIA_FILES[@]} + 5 > UPLOAD_RATE_LIMIT)); then
+	warn "${#MEDIA_FILES[@]} files + 5 negative cases exceeds the ${UPLOAD_RATE_LIMIT}/minute limit on /media/upload"
+	warn "expect 429s — trim $IMAGES_DIR or raise the limit on upload_media"
+fi
 
 curl -sf "$KRATOS_PUBLIC/health/ready" >/dev/null || fail "kratos not ready at $KRATOS_PUBLIC"
 ok "kratos ready"
@@ -675,10 +695,253 @@ step "28. DELETE /projects/{id}/thumbnail is idempotent"
 
 assert_http 200 DELETE "$KANAE/projects/$PROJECT_ID/thumbnail" -b "$COOKIES"
 
+# ── thumbnail upload/commit helpers ───────────────────────────────────────────
+
+# Run the two-step thumbnail staging flow against a resource base URL
+# ("$KANAE/projects/<id>" or "$KANAE/events/<id>"):
+#
+#   POST <base>/thumbnail/upload  → presigned PUT url, or the existing record
+#   PUT  <presigned url>          → only on the presign branch
+#   POST <base>/thumbnail/commit  → processes the WebP and attaches it
+#
+# Prints "<mode> <thumbnail_hash> <thumbnail_url>" on success, where mode is
+# "fresh" (presigned, bytes PUT) or "dedup" (hash already known, PUT skipped).
+#
+# Everything the caller needs goes to stdout: callers invoke this inside a
+# command substitution, which runs the function in a subshell, so a global
+# assigned here would be discarded on return. Nothing else may be printed.
+thumbnail_flow() {
+	local base="$1" file="$2" hash="$3" size="$4" content_type="$5"
+	local body="{\"hash\":\"$hash\",\"content_type\":\"$content_type\",\"size\":$size}"
+	local mode
+
+	local upload_resp
+	upload_resp=$(curl -s -X POST "$base/thumbnail/upload" \
+		-b "$COOKIES" \
+		-H "$H_CONTENT_TYPE" \
+		-d "$body")
+
+	if [[ "$(jq -r 'has("hash")' <<<"$upload_resp")" == "true" ]]; then
+		# Dedup branch: the hash is already in `media`, so the bytes are
+		# already in the bucket and there is nothing to PUT.
+		mode="dedup"
+	else
+		mode="fresh"
+
+		local url put_code
+		url=$(jq -r '.url // empty' <<<"$upload_resp")
+		[[ -n "$url" ]] \
+			|| fail "no presigned url in thumbnail upload response: $upload_resp"
+
+		put_code=$(curl -s -o /dev/null -w '%{http_code}' \
+			-X PUT "$url" \
+			-H "Content-Type: $content_type" \
+			--data-binary "@$file")
+		[[ "$put_code" =~ ^2[0-9][0-9]$ ]] \
+			|| fail "PUT to thumbnail presigned url returned $put_code (expected 2xx)"
+	fi
+
+	local commit_resp thumb_hash thumb_url
+	commit_resp=$(curl -s -X POST "$base/thumbnail/commit" \
+		-b "$COOKIES" \
+		-H "$H_CONTENT_TYPE" \
+		-d "$body")
+	thumb_hash=$(jq -r "$JQ_HASH" <<<"$commit_resp")
+	thumb_url=$(jq -r '.url // empty' <<<"$commit_resp")
+	[[ -n "$thumb_hash" && -n "$thumb_url" ]] \
+		|| fail "thumbnail commit failed: $commit_resp"
+
+	# Commit returns the *processed* WebP, not the source that was uploaded,
+	# so its digest must differ from the source hash.
+	[[ "$thumb_hash" != "$hash" ]] \
+		|| fail "commit echoed the source hash instead of the processed WebP digest"
+
+	printf '%s %s %s\n' "$mode" "$thumb_hash" "$thumb_url"
+}
+
+# ── 29. detach the thumbnail source so the staging flow starts cold ───────────
+step "29. DELETE /media/<hash> reaps the source, making the next upload fresh"
+
+# remove_project_media drops the media row and the S3 object once no
+# project_media rows reference the hash, so this hash becomes unknown to both
+# the DB and the bucket — which is what forces the presign branch below.
+assert_http 200 DELETE "$KANAE/projects/$PROJECT_ID/media/$THUMB_SRC_HASH" -b "$COOKIES"
+
+THUMB_SRC_SIZE=$(stat -c %s "$THUMB_SRC_FILE")
+
+# ── 30. project thumbnail via upload -> PUT -> commit ─────────────────────────
+step "30. POST /projects/{id}/thumbnail/upload + /commit (full staging flow)"
+
+FLOW_RESULT=$(thumbnail_flow \
+	"$KANAE/projects/$PROJECT_ID" \
+	"$THUMB_SRC_FILE" "$THUMB_SRC_HASH" "$THUMB_SRC_SIZE" "$THUMB_SRC_CT")
+# `read` with a here-string runs in the current shell, so these persist.
+read -r STAGED_MODE STAGED_HASH STAGED_URL <<<"$FLOW_RESULT"
+
+[[ "$STAGED_MODE" == "fresh" ]] \
+	|| warn "expected the presign branch after the reap, took '$STAGED_MODE' instead"
+ok "$STAGED_MODE flow committed thumbnail $STAGED_HASH"
+printf "    %s\n" "$STAGED_URL"
+
+# ── 31. the committed thumbnail is the project's thumbnail ────────────────────
+step "31. GET /projects/{id} reflects the committed thumbnail"
+
+STAGED_PROJ=$(curl -s -b "$COOKIES" "$KANAE/projects/$PROJECT_ID")
+STAGED_PROJ_HASH=$(jq -r '.thumbnail.hash // empty' <<<"$STAGED_PROJ")
+[[ "$STAGED_PROJ_HASH" == "$STAGED_HASH" ]] \
+	|| fail "project thumbnail is $STAGED_PROJ_HASH, expected $STAGED_HASH"
+ok "project.thumbnail.hash matches the commit response"
+
+# The commit also re-linked the source into project_media, so the reaped hash
+# is back in the project's media list.
+STAGED_LIST=$(curl -s -b "$COOKIES" "$KANAE/projects/$PROJECT_ID/media")
+jq -e --arg h "$THUMB_SRC_HASH" 'any(.[]; .hash == $h)' <<<"$STAGED_LIST" >/dev/null \
+	|| fail "commit did not re-link the source media: $STAGED_LIST"
+ok "commit re-linked the source into project_media"
+
+STAGED_CHECK=$(curl -s -o /dev/null -w '%{http_code} %{content_type}' "$STAGED_URL")
+STAGED_STATUS="${STAGED_CHECK%% *}"
+STAGED_TYPE="${STAGED_CHECK#* }"
+if [[ "$STAGED_STATUS" == "200" && "$STAGED_TYPE" == image/webp* ]]; then
+	ok "staged thumbnail URL serves bytes anonymously ($STAGED_STATUS, $STAGED_TYPE)"
+else
+	warn "staged thumbnail URL did not return 200 + image/webp (status=$STAGED_STATUS, type=$STAGED_TYPE)"
+fi
+
+# ── 32. negatives on the project staging routes ───────────────────────────────
+step "32. validation guards on /thumbnail/upload"
+
+# The guard matrix runs on the upload route. validate_thumbnail is one shared
+# function that all four thumbnail handlers call identically, so re-asserting
+# each case against commit buys no coverage — and commit only has 3/minute to
+# spend, which this script needs for the real commit above plus the 409 in
+# step 37. The commit-specific 404 runs once, on the event route in step 36.
+
+# Video content type → 400, not the 415 that /media/upload answers with. The
+# thumbnail validator narrows to images and reports it as a bad request.
+assert_http 400 POST "$KANAE/projects/$PROJECT_ID/thumbnail/upload" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"video/mp4","size":1024}'
+
+# Same input, the other validator — 415 here, 400 above.
+assert_http 415 POST "$KANAE/projects/$PROJECT_ID/media/upload" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"application/pdf","size":1024}'
+
+assert_http 400 POST "$KANAE/projects/$PROJECT_ID/thumbnail/upload" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"image/png","size":0}'
+
+# Over the 32 MB thumbnail cap.
+assert_http 413 POST "$KANAE/projects/$PROJECT_ID/thumbnail/upload" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"image/png","size":33554433}'
+
+# ── 33. create an event to exercise the same flow without a bridge table ──────
+step "33. grant leads role and create an event"
+
+curl -sf -X PUT "$KETO_WRITE/admin/relation-tuples" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{
+    "namespace":  "Role",
+    "object":     "leads",
+    "relation":   "member",
+    "subject_id": "'"$IDENTITY_ID"'"
+  }' >/dev/null
+docker exec "$VALKEY_CONTAINER" valkey-cli FLUSHDB >/dev/null
+ok "Role:leads#member tuple written, cache flushed"
+
+# `id` is required by the request model (create_events takes a full `Events`)
+# but is then dropped via exclude={"id", "creator_id"} — Postgres mints the
+# real UUID, and the response carries it. So this value is a placeholder that
+# never reaches the database; PROJECT_ID-style reuse of it would be wrong.
+# creator_id is optional and comes from the session, so it's omitted.
+EVENT_BODY='{
+  "id": "00000000-0000-4000-8000-000000000000",
+  "name": "Media Test Event",
+  "description": "for thumbnail route tests",
+  "start_at": "2099-01-01T00:00:00Z",
+  "end_at":   "2099-01-01T02:00:00Z",
+  "location": "Online",
+  "type": "general",
+  "timezone": "America/Los_Angeles"
+}'
+EVENT_RESP=$(curl -s -X POST "$KANAE/events/create" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d "$EVENT_BODY")
+EVENT_ID=$(jq -r '.id // empty' <<<"$EVENT_RESP")
+[[ -n "$EVENT_ID" ]] || fail "event create failed: $EVENT_RESP"
+docker exec "$VALKEY_CONTAINER" valkey-cli FLUSHDB >/dev/null
+ok "event id: $EVENT_ID"
+
+# ── 34. event thumbnail via upload -> commit (dedup branch) ───────────────────
+step "34. POST /events/{id}/thumbnail/upload + /commit"
+
+# The source hash is back in `media` after step 30's commit, so this run takes
+# the dedup branch and skips the PUT — the other half of the upload route.
+# Events have no media-association table, so nothing is linked either way.
+EVENT_FLOW=$(thumbnail_flow \
+	"$KANAE/events/$EVENT_ID" \
+	"$THUMB_SRC_FILE" "$THUMB_SRC_HASH" "$THUMB_SRC_SIZE" "$THUMB_SRC_CT")
+read -r EVENT_MODE EVENT_THUMB_HASH EVENT_THUMB_URL <<<"$EVENT_FLOW"
+
+[[ "$EVENT_MODE" == "dedup" ]] \
+	|| warn "expected the dedup branch for a known hash, took '$EVENT_MODE' instead"
+ok "$EVENT_MODE flow committed thumbnail $EVENT_THUMB_HASH"
+printf "    %s\n" "$EVENT_THUMB_URL"
+
+# Same source bytes as the project thumbnail, so the processed WebP is
+# content-identical and lands on the same hash.
+[[ "$EVENT_THUMB_HASH" == "$STAGED_HASH" ]] \
+	|| warn "event thumbnail hash $EVENT_THUMB_HASH differs from the project's $STAGED_HASH for identical source bytes"
+
+# ── 35. the committed thumbnail is the event's thumbnail ──────────────────────
+step "35. GET /events/{id} reflects the committed thumbnail"
+
+EVENT_GET=$(curl -s -b "$COOKIES" "$KANAE/events/$EVENT_ID")
+EVENT_GET_HASH=$(jq -r '.thumbnail.hash // empty' <<<"$EVENT_GET")
+[[ "$EVENT_GET_HASH" == "$EVENT_THUMB_HASH" ]] \
+	|| fail "event thumbnail is $EVENT_GET_HASH, expected $EVENT_THUMB_HASH"
+ok "event.thumbnail.hash matches the commit response"
+
+# ── 36. negatives on the event staging routes ─────────────────────────────────
+step "36. validation guards on the event staging routes"
+
+assert_http 400 POST "$KANAE/events/$EVENT_ID/thumbnail/upload" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"video/mp4","size":1024}'
+
+assert_http 404 POST "$KANAE/events/$EVENT_ID/thumbnail/commit" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d '{"hash":"deadbeefcafebabefacefedbadc0debead5badc0ffeefedfeedbabec0dedeadc","content_type":"image/png","size":1024}'
+
+# ── 37. commit with a mismatched declared size -> 409 ─────────────────────────
+step "37. POST /thumbnail/commit with the wrong size -> 409"
+
+# head reports the real object size, which won't match the inflated declaration.
+# Destructive on purpose and therefore last: the route deletes the source
+# object from the bucket before answering, so the source can't be committed
+# again after this. The already-processed WebPs live in the public bucket and
+# are unaffected, so the thumbnails set above keep working.
+assert_http 409 POST "$KANAE/projects/$PROJECT_ID/thumbnail/commit" \
+	-b "$COOKIES" \
+	-H "$H_CONTENT_TYPE" \
+	-d "{\"hash\":\"$THUMB_SRC_HASH\",\"content_type\":\"$THUMB_SRC_CT\",\"size\":$((THUMB_SRC_SIZE + 1))}"
+
+ok "source object was discarded by the size-mismatch guard"
+
 # ── done ──────────────────────────────────────────────────────────────────────
 printf '\n%sall media + thumbnail flow checks passed%s\n' "$GRN" "$RST"
 printf "  identity id: %s\n" "$IDENTITY_ID"
 printf "  project id:  %s\n" "$PROJECT_ID"
+printf "  event id:    %s\n" "$EVENT_ID"
 printf "  hashes:\n"
 for h in "${HASHES[@]}"; do
 	printf "    %s\n" "$h"

--- a/src/core.py
+++ b/src/core.py
@@ -152,6 +152,7 @@ _TARGET_CHUNK_COUNT = 128
 _ONE_MIB = 1024 * 1024
 _TARGET_BUCKET = _TARGET_CHUNK_COUNT * _ONE_MIB
 
+_MAX_THUMBNAIL_SIZE = 32 * 1024 * 1024  # 32 MB
 _THUMBNAIL_MAX_W = 1600
 _THUMBNAIL_MAX_H = 500
 _WEBP_QUALITY = 75
@@ -496,6 +497,33 @@ async def store_thumbnail(
     )
 
     return processed_image
+
+
+def validate_thumbnail(content_type: str, size: int) -> None:
+    """Validates whether a given thumbnail source is valid or not
+
+    Args:
+        content_type (str): The source's MIME type
+        size (int): Size of the source in bytes
+
+    Raises:
+        BadRequestError: Thumbnail source is not valid
+        HTTPException: Whether the source is too large
+    """
+    if content_type not in ALLOWED_IMAGE_TYPES:
+        msg = "Thumbnail must be an image"
+        raise BadRequestError(msg)
+
+    if size <= 0:
+        msg = "Size must be positive"
+        raise BadRequestError(msg)
+
+    if size > _MAX_THUMBNAIL_SIZE:
+        msg = f"Thumbnail size {size} exceeds limit {_MAX_THUMBNAIL_SIZE}"
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=msg,
+        )
 
 
 class ProcessedThumbnail(NamedTuple):

--- a/src/core.py
+++ b/src/core.py
@@ -16,6 +16,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Annotated,
     Any,
     ClassVar,
     Literal,
@@ -54,7 +55,7 @@ from prometheus_client import (
     generate_latest,
 )
 from prometheus_fastapi_instrumentator import metrics, routing
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.datastructures import Headers
 
 from utils.cache import ORJSONSerializer, ValkeyCache, cached_method
@@ -157,6 +158,9 @@ _THUMBNAIL_MAX_W = 1600
 _THUMBNAIL_MAX_H = 500
 _WEBP_QUALITY = 75
 _WEBP_EFFORT = 6
+
+_HASH_REGEX = r"^[0-9a-f]{64}$"
+_NO_NULL_REGEX = r"^[^\x00]+$"
 
 
 def _is_docker() -> bool:
@@ -551,6 +555,15 @@ class MultipartUpload(BaseModel, frozen=True):
 class MultipartUploadChunks(NamedTuple):
     chunk_index: int
     etag: str
+
+
+class MediaRecord(BaseModel, frozen=True):
+    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
+    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    kind: Literal["image", "video"]
+    size: int
+    created_at: datetime.datetime
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 
 class StorageClient:

--- a/src/core.py
+++ b/src/core.py
@@ -557,6 +557,12 @@ class MultipartUploadChunks(NamedTuple):
     etag: str
 
 
+class UploadRequest(BaseModel, frozen=True):
+    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
+    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    size: int
+
+
 class MediaRecord(BaseModel, frozen=True):
     hash: Annotated[str, Field(pattern=_HASH_REGEX)]
     content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -4,12 +4,16 @@ from typing import Annotated, Literal, Optional, Self
 
 import asyncpg
 import base62
+from botocore.exceptions import ClientError
 from dateutil import tz
 from dateutil.relativedelta import relativedelta
 from fastapi import Depends, HTTPException, Query
 from pydantic import BaseModel, Field, model_validator
 
-from core import store_thumbnail
+from core import (
+    store_thumbnail,
+    validate_thumbnail,
+)
 from utils.auth import use_session
 from utils.checks import Event, Role, has_any_role, has_permissions
 from utils.errors import (
@@ -377,6 +381,156 @@ async def create_events(
         else:
             await tr.commit()
             return Events(**dict(rows))
+
+
+class SimpleUploadResponse(BaseModel, frozen=True):
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+
+
+class MediaRecord(BaseModel, frozen=True):
+    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
+    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    kind: Literal["image", "video"]
+    size: int
+    created_at: datetime.datetime
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+
+
+class UploadRequest(BaseModel, frozen=True):
+    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
+    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    size: int
+
+
+@router.post(
+    "/events/{event_id}/thumbnail/upload",
+    dependencies=[has_permissions(Event.edit)],
+    responses={
+        200: {"model": MediaRecord},
+        400: {"model": BadRequestResponse},
+        403: {"model": ForbiddenResponse},
+        413: {"model": HTTPExceptionResponse},
+    },
+)
+@router.limiter.limit("10/minute")
+async def upload_event_thumbnail(
+    request: RouteRequest,
+    event_id: uuid.UUID,
+    req: UploadRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> MediaRecord | SimpleUploadResponse:
+    """Begin a thumbnail upload by minting a presigned URL or returning the existing record"""
+    validate_thumbnail(req.content_type, req.size)
+
+    query = """
+    SELECT hash, content_type, kind, size, created_at
+    FROM media
+    WHERE hash = $1;
+    """
+
+    exists = await request.app.pool.fetchrow(query, req.hash)
+    if exists:
+        url = await request.app.storage.get_url(exists["hash"], exists["content_type"])
+        return MediaRecord(**dict(exists), url=url)
+
+    url = await request.app.storage.upload(req.hash, content_type=req.content_type)
+    return SimpleUploadResponse(url=url)
+
+
+@router.post(
+    "/events/{event_id}/thumbnail/commit",
+    dependencies=[has_permissions(Event.edit)],
+    responses={
+        200: {"model": EventThumbnail},
+        400: {"model": BadRequestResponse},
+        403: {"model": ForbiddenResponse},
+        404: {"model": NotFoundResponse},
+        409: {"model": ConflictResponse},
+        413: {"model": HTTPExceptionResponse},
+    },
+)
+@router.limiter.limit("10/minute")
+async def commit_event_thumbnail(
+    request: RouteRequest,
+    event_id: uuid.UUID,
+    req: UploadRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> EventThumbnail:
+    """Finalize a thumbnail upload, then process and attach it to the event"""
+    validate_thumbnail(req.content_type, req.size)
+
+    try:
+        head = await request.app.storage.head(req.hash, content_type=req.content_type)
+    except ClientError:
+        msg = "No such media exists"
+        raise NotFoundError(msg)
+
+    if head["ContentLength"] != req.size:
+        await request.app.storage.delete(req.hash, content_type=req.content_type)
+
+        msg = "Uploaded size does not match declared size"
+        raise ConflictError(msg)
+
+    processed_image = await store_thumbnail(
+        request, media_hash=req.hash, content_type=req.content_type
+    )
+
+    query = """
+        WITH insert_media AS (
+            INSERT INTO media (hash, content_type, size, creator_id)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (hash) DO UPDATE
+                SET hash = EXCLUDED.hash
+            RETURNING hash
+        ), locked AS (
+            SELECT thumbnail_hash FROM events
+            WHERE id = $5
+            FOR UPDATE
+        ), old AS (
+            SELECT thumbnail_hash FROM locked
+            WHERE thumbnail_hash IS NOT NULL AND thumbnail_hash != $6
+        )
+        UPDATE events
+        SET thumbnail_hash = $6
+        WHERE id = $5
+        RETURNING id, (SELECT thumbnail_hash FROM old) AS old_hash;
+    """
+    async with request.app.pool.acquire() as connection:
+        tr = connection.transaction()
+        await tr.start()
+        try:
+            response = await connection.fetchrow(
+                query,
+                req.hash,
+                req.content_type,
+                req.size,
+                session.identity.id,
+                event_id,
+                processed_image.hash,
+            )
+
+            if response is None:
+                await tr.rollback()
+                await request.app.storage.delete_thumbnail(processed_image.hash)
+
+                msg = "Event not found"
+                raise NotFoundError(msg)
+        except asyncpg.ForeignKeyViolationError:
+            await tr.rollback()
+
+            await request.app.storage.delete_thumbnail(processed_image.hash)
+            msg = "Creator no longer exists"
+            raise NotFoundError(msg)
+        else:
+            await tr.commit()
+
+    if response["old_hash"]:
+        await request.app.storage.delete_thumbnail(response["old_hash"])
+
+    return EventThumbnail(
+        hash=processed_image.hash,
+        url=request.app.storage.get_thumbnail_url(processed_image.hash),
+    )
 
 
 class SetThumbnailRequest(BaseModel, frozen=True):

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -10,10 +10,7 @@ from dateutil.relativedelta import relativedelta
 from fastapi import Depends, HTTPException, Query
 from pydantic import BaseModel, Field, model_validator
 
-from core import (
-    store_thumbnail,
-    validate_thumbnail,
-)
+from core import MediaRecord, store_thumbnail, validate_thumbnail
 from utils.auth import use_session
 from utils.checks import Event, Role, has_any_role, has_permissions
 from utils.errors import (
@@ -384,15 +381,6 @@ async def create_events(
 
 
 class SimpleUploadResponse(BaseModel, frozen=True):
-    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-
-
-class MediaRecord(BaseModel, frozen=True):
-    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
-    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-    kind: Literal["image", "video"]
-    size: int
-    created_at: datetime.datetime
     url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 from fastapi import Depends, HTTPException, Query
 from pydantic import BaseModel, Field, model_validator
 
-from core import MediaRecord, store_thumbnail, validate_thumbnail
+from core import MediaRecord, UploadRequest, store_thumbnail, validate_thumbnail
 from utils.auth import use_session
 from utils.checks import Event, Role, has_any_role, has_permissions
 from utils.errors import (
@@ -32,7 +32,6 @@ from utils.responses import (
     HTTPExceptionResponse,
     JoinResponse,
     NotFoundResponse,
-    SimpleUploadResponse,
     SuccessResponse,
 )
 from utils.router import KanaeRouter
@@ -381,10 +380,8 @@ async def create_events(
             return Events(**dict(rows))
 
 
-class UploadRequest(BaseModel, frozen=True):
-    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
-    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-    size: int
+class SimpleUploadResponse(BaseModel, frozen=True):
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 
 @router.post(

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -32,6 +32,7 @@ from utils.responses import (
     HTTPExceptionResponse,
     JoinResponse,
     NotFoundResponse,
+    SimpleUploadResponse,
     SuccessResponse,
 )
 from utils.router import KanaeRouter
@@ -378,10 +379,6 @@ async def create_events(
         else:
             await tr.commit()
             return Events(**dict(rows))
-
-
-class SimpleUploadResponse(BaseModel, frozen=True):
-    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 
 class UploadRequest(BaseModel, frozen=True):

--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from core import (
     ALLOWED_IMAGE_TYPES,
     ALLOWED_VIDEO_TYPES,
+    MediaRecord,
     MultipartUploadChunks,
     UploadChunk,
     store_thumbnail,
@@ -1405,15 +1406,6 @@ class MultipartUploadResponse(BaseModel, frozen=True):
     chunks: list[UploadChunk]
 
 
-class MediaRecord(BaseModel, frozen=True):
-    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
-    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-    kind: Literal["image", "video"]
-    size: int
-    created_at: datetime.datetime
-    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-
-
 class UploadRequest(BaseModel, frozen=True):
     hash: Annotated[str, Field(pattern=_HASH_REGEX)]
     content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
@@ -1430,13 +1422,7 @@ class UploadRequest(BaseModel, frozen=True):
         415: {"model": HTTPExceptionResponse},
     },
 )
-# Higher than the 10/minute write norm because callers spend one request per
-# *file*, not per user action: a gallery drop of N files is N uploads within a
-# few seconds. The handler is cheap — one indexed SELECT plus a local SigV4
-# presign, with no S3 round-trip — so the ceiling is about bounding request
-# volume, not protecting work. Matches list_project_media, the other route
-# whose cardinality follows the media count.
-@router.limiter.limit("60/minute")
+@router.limiter.limit("10/minute")
 async def upload_media(
     request: RouteRequest,
     project_id: uuid.UUID,
@@ -1506,10 +1492,7 @@ class CommitRequest(BaseModel, frozen=True):
         502: {"model": HTTPExceptionResponse},
     },
 )
-# Paired one-for-one with upload_media, so it needs the same ceiling — a batch
-# that can presign N files has to be able to finalize N files. One S3 HEAD plus
-# one INSERT per call, no CPU work.
-@router.limiter.limit("60/minute")
+@router.limiter.limit("10/minute")
 async def commit_media(
     request: RouteRequest,
     project_id: uuid.UUID,

--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -38,6 +38,7 @@ from utils.responses import (
     HTTPExceptionResponse,
     JoinResponse,
     NotFoundResponse,
+    SimpleUploadResponse,
     SuccessResponse,
 )
 from utils.router import KanaeRouter
@@ -1394,10 +1395,6 @@ def _validate_media(content_type: str, size: int) -> None:
             status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=msg,
         )
-
-
-class SimpleUploadResponse(BaseModel, frozen=True):
-    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
 
 
 class MultipartUploadResponse(BaseModel, frozen=True):

--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -14,6 +14,7 @@ from core import (
     MultipartUploadChunks,
     UploadChunk,
     store_thumbnail,
+    validate_thumbnail,
 )
 from utils.auth import use_session
 from utils.checks import Project, Role, check_any, has_permissions, has_role
@@ -1429,7 +1430,13 @@ class UploadRequest(BaseModel, frozen=True):
         415: {"model": HTTPExceptionResponse},
     },
 )
-@router.limiter.limit("10/minute")
+# Higher than the 10/minute write norm because callers spend one request per
+# *file*, not per user action: a gallery drop of N files is N uploads within a
+# few seconds. The handler is cheap — one indexed SELECT plus a local SigV4
+# presign, with no S3 round-trip — so the ceiling is about bounding request
+# volume, not protecting work. Matches list_project_media, the other route
+# whose cardinality follows the media count.
+@router.limiter.limit("60/minute")
 async def upload_media(
     request: RouteRequest,
     project_id: uuid.UUID,
@@ -1499,7 +1506,10 @@ class CommitRequest(BaseModel, frozen=True):
         502: {"model": HTTPExceptionResponse},
     },
 )
-@router.limiter.limit("10/minute")
+# Paired one-for-one with upload_media, so it needs the same ceiling — a batch
+# that can presign N files has to be able to finalize N files. One S3 HEAD plus
+# one INSERT per call, no CPU work.
+@router.limiter.limit("60/minute")
 async def commit_media(
     request: RouteRequest,
     project_id: uuid.UUID,
@@ -1589,6 +1599,151 @@ async def commit_media(
     )
 
 
+@router.post(
+    "/projects/{project_id}/thumbnail/upload",
+    dependencies=[has_permissions(Project.edit)],
+    responses={
+        200: {"model": MediaRecord},
+        400: {"model": BadRequestResponse},
+        403: {"model": ForbiddenResponse},
+        413: {"model": HTTPExceptionResponse},
+    },
+)
+@router.limiter.limit("10/minute")
+async def upload_project_thumbnail(
+    request: RouteRequest,
+    project_id: uuid.UUID,
+    req: UploadRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> MediaRecord | SimpleUploadResponse:
+    """Begin a thumbnail upload by minting a presigned URL or returning the existing record"""
+    validate_thumbnail(req.content_type, req.size)
+
+    query = """
+    WITH media_exists AS (
+        SELECT hash, content_type, kind, size, created_at
+        FROM media
+        WHERE hash = $1
+    ),
+    link AS (
+        INSERT INTO project_media (project_id, media_hash)
+        SELECT $2, hash FROM media_exists
+        ON CONFLICT DO NOTHING
+    )
+    SELECT hash, content_type, kind, size, created_at FROM media_exists;
+    """
+
+    exists = await request.app.pool.fetchrow(query, req.hash, project_id)
+    if exists:
+        url = await request.app.storage.get_url(exists["hash"], exists["content_type"])
+        return MediaRecord(**dict(exists), url=url)
+
+    url = await request.app.storage.upload(req.hash, content_type=req.content_type)
+    return SimpleUploadResponse(url=url)
+
+
+@router.post(
+    "/projects/{project_id}/thumbnail/commit",
+    dependencies=[has_permissions(Project.edit)],
+    responses={
+        200: {"model": ProjectThumbnail},
+        400: {"model": BadRequestResponse},
+        403: {"model": ForbiddenResponse},
+        404: {"model": NotFoundResponse},
+        409: {"model": ConflictResponse},
+        413: {"model": HTTPExceptionResponse},
+    },
+)
+@router.limiter.limit("10/minute")
+async def commit_project_thumbnail(
+    request: RouteRequest,
+    project_id: uuid.UUID,
+    req: UploadRequest,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> ProjectThumbnail:
+    """Finalize a thumbnail upload, then process and attach it to the project"""
+    validate_thumbnail(req.content_type, req.size)
+
+    try:
+        head = await request.app.storage.head(req.hash, content_type=req.content_type)
+    except ClientError:
+        msg = "No such media exists"
+        raise NotFoundError(msg)
+
+    if head["ContentLength"] != req.size:
+        await request.app.storage.delete(req.hash, content_type=req.content_type)
+
+        msg = "Uploaded size does not match declared size"
+        raise ConflictError(msg)
+
+    processed_image = await store_thumbnail(
+        request, media_hash=req.hash, content_type=req.content_type
+    )
+
+    query = """
+        WITH insert_media AS (
+            INSERT INTO media (hash, content_type, size, creator_id)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (hash) DO UPDATE
+                SET hash = EXCLUDED.hash
+            RETURNING hash
+        ), link AS (
+            INSERT INTO project_media (project_id, media_hash)
+            SELECT $5, hash FROM insert_media
+            ON CONFLICT DO NOTHING
+        ), locked AS (
+            SELECT thumbnail_hash FROM projects
+            WHERE id = $5
+            FOR UPDATE
+        ), old AS (
+            SELECT thumbnail_hash FROM locked
+            WHERE thumbnail_hash IS NOT NULL AND thumbnail_hash != $6
+        )
+        UPDATE projects
+        SET thumbnail_hash = $6
+        WHERE id = $5
+        RETURNING id, (SELECT thumbnail_hash FROM old) AS old_hash;
+    """
+    async with request.app.pool.acquire() as connection:
+        tr = connection.transaction()
+        await tr.start()
+
+        try:
+            response = await connection.fetchrow(
+                query,
+                req.hash,
+                req.content_type,
+                req.size,
+                session.identity.id,
+                project_id,
+                processed_image.hash,
+            )
+
+            if response is None:
+                await tr.rollback()
+                await request.app.storage.delete_thumbnail(processed_image.hash)
+
+                msg = "Project no longer exists"
+                raise NotFoundError(msg)
+
+        except asyncpg.ForeignKeyViolationError:
+            await tr.rollback()
+
+            await request.app.storage.delete_thumbnail(processed_image.hash)
+            msg = "Project or creator no longer exists"
+            raise NotFoundError(msg)
+        else:
+            await tr.commit()
+
+    if response["old_hash"]:
+        await request.app.storage.delete_thumbnail(response["old_hash"])
+
+    return ProjectThumbnail(
+        hash=processed_image.hash,
+        url=request.app.storage.get_thumbnail_url(processed_image.hash),
+    )
+
+
 class SetThumbnailRequest(BaseModel, frozen=True):
     hash: Annotated[str, Field(pattern=_HASH_REGEX)]
     content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
@@ -1656,6 +1811,45 @@ async def set_project_thumbnail(
         await request.app.storage.delete_thumbnail(response["old_hash"])
 
     return SuccessResponse(message="ok")
+
+
+@router.delete(
+    "/projects/{project_id}/thumbnail",
+    dependencies=[has_permissions(Project.edit)],
+    responses={
+        200: {"model": DeleteResponse},
+        403: {"model": ForbiddenResponse},
+        404: {"model": NotFoundResponse},
+    },
+)
+@router.limiter.limit("5/minute")
+async def remove_project_thumbnail(
+    request: RouteRequest,
+    project_id: uuid.UUID,
+    session: Annotated[KanaeSession, Depends(use_session)],
+) -> DeleteResponse:
+    """Removes the associated thumbnail of a given project"""
+    query = """
+    WITH old_thumbnail AS (
+        SELECT thumbnail_hash
+        FROM projects
+        WHERE id = $1
+    )
+    UPDATE projects
+    SET thumbnail_hash = NULL
+    WHERE id = $1
+    RETURNING id, (SELECT thumbnail_hash FROM old_thumbnail) AS old_hash
+    """
+
+    response = await request.app.pool.fetchrow(query, project_id)
+
+    if not response:
+        raise NotFoundError
+
+    if response["old_hash"]:
+        await request.app.storage.delete_thumbnail(response["old_hash"])
+
+    return DeleteResponse()
 
 
 @router.get(
@@ -1795,42 +1989,3 @@ async def remove_project_media(
             )
 
         return DeleteResponse()
-
-
-@router.delete(
-    "/projects/{project_id}/thumbnail",
-    dependencies=[has_permissions(Project.edit)],
-    responses={
-        200: {"model": DeleteResponse},
-        403: {"model": ForbiddenResponse},
-        404: {"model": NotFoundResponse},
-    },
-)
-@router.limiter.limit("5/minute")
-async def remove_project_thumbnail(
-    request: RouteRequest,
-    project_id: uuid.UUID,
-    session: Annotated[KanaeSession, Depends(use_session)],
-) -> DeleteResponse:
-    """Removes the associated thumbnail of a given project"""
-    query = """
-    WITH old_thumbnail AS (
-        SELECT thumbnail_hash
-        FROM projects
-        WHERE id = $1
-    )
-    UPDATE projects
-    SET thumbnail_hash = NULL
-    WHERE id = $1
-    RETURNING id, (SELECT thumbnail_hash FROM old_thumbnail) AS old_hash
-    """
-
-    response = await request.app.pool.fetchrow(query, project_id)
-
-    if not response:
-        raise NotFoundError
-
-    if response["old_hash"]:
-        await request.app.storage.delete_thumbnail(response["old_hash"])
-
-    return DeleteResponse()

--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -14,6 +14,7 @@ from core import (
     MediaRecord,
     MultipartUploadChunks,
     UploadChunk,
+    UploadRequest,
     store_thumbnail,
     validate_thumbnail,
 )
@@ -38,7 +39,6 @@ from utils.responses import (
     HTTPExceptionResponse,
     JoinResponse,
     NotFoundResponse,
-    SimpleUploadResponse,
     SuccessResponse,
 )
 from utils.router import KanaeRouter
@@ -1397,16 +1397,14 @@ def _validate_media(content_type: str, size: int) -> None:
         )
 
 
+class SimpleUploadResponse(BaseModel, frozen=True):
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+
+
 class MultipartUploadResponse(BaseModel, frozen=True):
     upload_id: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
     size: int
     chunks: list[UploadChunk]
-
-
-class UploadRequest(BaseModel, frozen=True):
-    hash: Annotated[str, Field(pattern=_HASH_REGEX)]
-    content_type: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
-    size: int
 
 
 @router.post(

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -1,12 +1,14 @@
 import json
 from collections.abc import Sequence
-from typing import Any
+from typing import Annotated, Any
 
 import orjson
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 HTTP_404_DETAIL = "Resource not found"
+
+_NO_NULL_REGEX = r"^[^\x00]+$"
 
 
 class ORJSONResponse(JSONResponse):
@@ -93,3 +95,8 @@ class DeleteResponse(SuccessResponse, frozen=True):
 
 class JoinResponse(SuccessResponse, frozen=True):
     message: str = "Successfully joined"
+
+
+### Other responses
+class SimpleUploadResponse(BaseModel, frozen=True):
+    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -1,14 +1,12 @@
 import json
 from collections.abc import Sequence
-from typing import Annotated, Any
+from typing import Any
 
 import orjson
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 HTTP_404_DETAIL = "Resource not found"
-
-_NO_NULL_REGEX = r"^[^\x00]+$"
 
 
 class ORJSONResponse(JSONResponse):
@@ -95,8 +93,3 @@ class DeleteResponse(SuccessResponse, frozen=True):
 
 class JoinResponse(SuccessResponse, frozen=True):
     message: str = "Successfully joined"
-
-
-### Other responses
-class SimpleUploadResponse(BaseModel, frozen=True):
-    url: Annotated[str, Field(pattern=_NO_NULL_REGEX)]

--- a/tests/integration/scenarios/43_thumbnail_upload_commit_matrix.hurl
+++ b/tests/integration/scenarios/43_thumbnail_upload_commit_matrix.hurl
@@ -1,0 +1,342 @@
+# Thumbnail upload/commit flow (access-control + validation matrix) for both
+# resources, covering the four routes no prior scenario touches:
+#
+#   POST /projects/{id}/thumbnail/upload
+#   POST /projects/{id}/thumbnail/commit
+#   POST /events/{id}/thumbnail/upload
+#   POST /events/{id}/thumbnail/commit
+#
+# Scenarios 25 and 26 cover the *set* form of the thumbnail routes
+# (POST /{projects,events}/{id}/thumbnail) plus the media upload/commit pair;
+# this file covers the thumbnail-specific staging flow layered on top.
+#
+# Dummy UUIDs with no DB row stand in for a real project/event, as in 25/26 —
+# Keto grants alone let every auth-gated path be reached. That works here
+# because neither upload route needs the resource row:
+#   - projects: the project_media link is inserted only when the hash already
+#     exists in `media`, and none of these hashes do
+#   - events: there is no bridge table at all, so `events` is never consulted
+#
+# Phase ordering follows the same dependency chain as 25/26: session check →
+# Keto check (raw path string, before UUID coercion) → Pydantic → handler.
+# So 401 short-circuits everything, 403 short-circuits Pydantic, and the 422s
+# are only observable as ADMIN holding the grant.
+#
+# Rate-limit budget — read before adding requests here. The two commit routes
+# allow 3/minute each, the two upload routes 10/minute. Per-route limits live
+# in KanaeLimiter._route_limits and are only collected with in_middleware=False
+# (utils/limiter/extension.py), i.e. from the decorator that wraps the handler.
+# So a request only spends budget if it *reaches the handler*: the 401s, 403s
+# and 422s below are free, while every 400/413/404/200 costs one. With
+# key_style="url" the key is the request path, so each dummy UUID is its own
+# bucket and projects/events don't share.
+#
+#   /projects/cccc…/thumbnail/upload   4 of 10
+#   /events/ffff…/thumbnail/upload     5 of 10
+#   /projects/cccc…/thumbnail/commit   2 of 3   (Phase 6 ordering + Phase 7 404)
+#   /events/ffff…/thumbnail/commit     2 of 3   (Phase 6 ordering + Phase 7 404)
+#   /projects/cccc…/media/upload       1 of 10
+#
+# An earlier revision ran the whole validate_thumbnail matrix against all four
+# routes and put the events commit at 4 handler-entering requests, which made
+# the Phase 7 404 come back 429.
+#
+#   auth matrix
+#     unauthenticated                   → 401   (Phase 2)
+#     authenticated, no Keto grant      → 403   (LEADS, Phase 3)
+#     authenticated, grant present      → 422 / 400 / 413 / 200 / 404
+#
+#   Pydantic 422 paths (Phase 5)
+#     missing hash / bad hash pattern / missing content_type / missing size
+#     `size` is required on both routes — unlike the set-thumbnail body,
+#     which takes only hash + content_type
+#
+#   validate_thumbnail (Phase 6)
+#     video content type                → 400  (NOT 415: thumbnails answer
+#                                               with 400 to match
+#                                               store_thumbnail, while
+#                                               _validate_media answers 415
+#                                               for the same input on
+#                                               /media/upload — see the
+#                                               contrast assertion below)
+#     non-media content type            → 400
+#     size ≤ 0                          → 400
+#     size over 32 MB thumbnail cap     → 413
+#
+#   storage-dependent paths (Phase 7)
+#     upload, hash unknown to `media`   → 200 + presigned PUT url. Presigning
+#                                         is local SigV4, so no object need
+#                                         exist for this to succeed.
+#     commit, object absent from bucket → 404 (head raises ClientError). This
+#                                         fires before any DB write, so the
+#                                         dummy resource row never matters.
+
+# ── Phase 1: Keto grants for ADMIN on the dummy project and event ────────────
+# (Keto admin API requires no user session)
+
+PUT {{KETO_WRITE_URL}}/admin/relation-tuples
+Content-Type: application/json
+Accept: application/json
+{ "namespace": "Project", "object": "cccccccc-cccc-4ccc-8ccc-cccccccccccc", "relation": "edit", "subject_id": "{{ADMIN_ID}}" }
+HTTP 201
+[Asserts]
+jsonpath "$.namespace" == "Project"
+jsonpath "$.relation" == "edit"
+
+PUT {{KETO_WRITE_URL}}/admin/relation-tuples
+Content-Type: application/json
+Accept: application/json
+{ "namespace": "Event", "object": "ffffffff-ffff-4fff-8fff-ffffffffffff", "relation": "edit", "subject_id": "{{ADMIN_ID}}" }
+HTTP 201
+[Asserts]
+jsonpath "$.namespace" == "Event"
+jsonpath "$.relation" == "edit"
+
+# ── Phase 2: Unauthenticated 401 on all four routes ──────────────────────────
+# A malformed body still returns 401 — the Kratos check short-circuits before
+# Pydantic sees the payload.
+
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "garbage": true }
+HTTP 401
+
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/commit
+Content-Type: application/json
+{ "garbage": true }
+HTTP 401
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "garbage": true }
+HTTP 401
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/commit
+Content-Type: application/json
+{ "garbage": true }
+HTTP 401
+
+# ── Phase 3: LEADS login → 403 (no grant on either dummy resource) ───────────
+
+GET {{KRATOS_URL}}/self-service/login/browser
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{LEADS_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{LEADS_ID}}"
+
+# Body-valid requests still 403 — the Keto check precedes the handler.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 1024 }
+HTTP 403
+
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/commit
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 1024 }
+HTTP 403
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 1024 }
+HTTP 403
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/commit
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 1024 }
+HTTP 403
+
+# ── Phase 4: Re-login as ADMIN (holds both grants) ───────────────────────────
+
+GET {{KRATOS_URL}}/self-service/login/browser?refresh=true
+Accept: application/json
+HTTP 200
+[Captures]
+flow_id: jsonpath "$.id"
+csrf: jsonpath "$.ui.nodes[?(@.attributes.name == 'csrf_token')].attributes.value"
+
+POST {{KRATOS_URL}}/self-service/login?flow={{flow_id}}
+Content-Type: application/json
+Accept: application/json
+{ "method": "password", "identifier": "{{ADMIN_EMAIL}}", "password": "{{PASSWORD}}", "csrf_token": "{{csrf}}" }
+HTTP 200
+[Asserts]
+jsonpath "$.session.identity.id" == "{{ADMIN_ID}}"
+
+# ── Phase 5: Pydantic 422 paths (ADMIN session + grants in place) ────────────
+
+# upload: missing hash.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "content_type": "image/jpeg", "size": 1024 }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].loc[*]" contains "hash"
+
+# upload: hash too short — _HASH_REGEX mismatch.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "tooshort", "content_type": "image/jpeg", "size": 1024 }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].type" contains "string_pattern_mismatch"
+
+# upload: missing content_type.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "size": 1024 }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].loc[*]" contains "content_type"
+
+# upload: missing size. The set-thumbnail route accepts a body without it;
+# these two do not.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg" }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].loc[*]" contains "size"
+
+# commit: missing size — same model, same rejection.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/commit
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg" }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].loc[*]" contains "size"
+
+# events upload: NUL byte in content_type — _NO_NULL_REGEX mismatch.
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/\u0000png", "size": 1024 }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].type" contains "string_pattern_mismatch"
+
+# events commit: bad hash pattern.
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/commit
+Content-Type: application/json
+{ "hash": "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "content_type": "image/jpeg", "size": 1024 }
+HTTP 422
+[Asserts]
+jsonpath "$.errors[*].type" contains "string_pattern_mismatch"
+
+# ── Phase 6: validate_thumbnail (ADMIN + grants) ─────────────────────────────
+#
+# The guard matrix runs on the *upload* routes. validate_thumbnail is a single
+# shared function that all four handlers call identically, so re-asserting
+# every case against every route buys no coverage — and it would blow the
+# commit routes' 3/minute budget (see the rate-limit note in the header).
+# Commit keeps only the case that is specific to it: that validation runs
+# before `head`.
+
+# Video content type → 400. Videos are perfectly valid *media*, so this is the
+# thumbnail-specific narrowing to the image allow-list.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "video/mp4", "size": 1024 }
+HTTP 400
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "video/mp4", "size": 1024 }
+HTTP 400
+
+# Content type outside the media allow-list entirely → still 400 here.
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "application/pdf", "size": 1024 }
+HTTP 400
+
+# The deliberate divergence, asserted side by side: the same unsupported type
+# is 415 on the media route (_validate_media) and 400 on the thumbnail route
+# (validate_thumbnail, matching store_thumbnail and POST .../thumbnail).
+# Both legs run against this scenario's own cccc… grant, so the contrast holds
+# without depending on any other scenario's Keto state.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/media/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "application/pdf", "size": 1024 }
+HTTP 415
+
+# size ≤ 0 → 400.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 0 }
+HTTP 400
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": -1 }
+HTTP 400
+
+# Over the 32 MB thumbnail cap → 413.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 33554433 }
+HTTP 413
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "image/jpeg", "size": 33554433 }
+HTTP 413
+
+# Content type is checked before size: a non-image that is *also* oversized
+# reports 400, not 413. This is the commit-specific half of the matrix —
+# without that ordering, `head` would derive a key from the bad content type
+# and 404 on the wrong thing. One request per commit route, leaving the second
+# of three for the 404 in Phase 7.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/commit
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "video/mp4", "size": 33554433 }
+HTTP 400
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/commit
+Content-Type: application/json
+{ "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "content_type": "video/mp4", "size": 33554433 }
+HTTP 400
+
+# ── Phase 7: storage-dependent paths (ADMIN + grants) ────────────────────────
+
+# upload with a hash absent from `media` → SimpleUploadResponse. Presigning is
+# local SigV4 against the configured credentials, so no object has to exist.
+# The response carries only `url`; the MediaRecord branch (with hash/kind/size)
+# is only taken for a hash already in the table.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/upload
+Content-Type: application/json
+{ "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "content_type": "image/jpeg", "size": 1024 }
+HTTP 200
+[Asserts]
+jsonpath "$.url" exists
+jsonpath "$.url" matches "^https?://"
+jsonpath "$.hash" not exists
+
+# Same on the events side — and this one additionally proves the route never
+# consults the `events` row, since ffff… has no DB record at all.
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/upload
+Content-Type: application/json
+{ "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "content_type": "image/jpeg", "size": 1024 }
+HTTP 200
+[Asserts]
+jsonpath "$.url" exists
+jsonpath "$.hash" not exists
+
+# commit for an object that was never PUT → head raises ClientError → 404.
+# This fires before any DB write, so the missing project row is never reached.
+POST {{KANAE_URL}}/projects/cccccccc-cccc-4ccc-8ccc-cccccccccccc/thumbnail/commit
+Content-Type: application/json
+{ "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "content_type": "image/jpeg", "size": 1024 }
+HTTP 404
+
+POST {{KANAE_URL}}/events/ffffffff-ffff-4fff-8fff-ffffffffffff/thumbnail/commit
+Content-Type: application/json
+{ "hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "content_type": "image/jpeg", "size": 1024 }
+HTTP 404

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -9,12 +9,13 @@ import hiro
 import pytest
 from conftest import FakeOryClient, KanaeTestClient
 
-from core import Kanae
+from core import _MAX_THUMBNAIL_SIZE, Kanae
 from utils.checks import Role
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 _VALID_HASH = "a" * 64  # 64 hex chars to match the route's _HASH_REGEX
+_OVERSIZED_THUMBNAIL = _MAX_THUMBNAIL_SIZE + 1
 
 
 async def _insert_member(
@@ -90,6 +91,27 @@ def _valid_event_payload(
         "timezone": "UTC",
         "creator_id": str(creator_id) if creator_id else str(uuid.uuid4()),
     }
+
+
+async def _insert_media(
+    pool: asyncpg.Pool,
+    *,
+    media_hash: str,
+    content_type: str = "image/png",
+    size: int = 1024,
+    creator_id: uuid.UUID | str | None = None,
+) -> None:
+    # `kind` is a generated column derived from content_type, so it's omitted.
+    await pool.execute(
+        """
+        INSERT INTO media (hash, content_type, size, creator_id)
+        VALUES ($1, $2, $3, $4)
+        """,
+        media_hash,
+        content_type,
+        size,
+        creator_id,
+    )
 
 
 async def _insert_tag(
@@ -1519,3 +1541,206 @@ async def test_roleless_member_still_denied_event_attendance(
 
     response = await client.client.get(f"/events/{event_id}/attendance")
     assert response.status_code == 403
+
+
+# ──────────────────────────────────────────────────────────────────
+# Thumbnail upload and commit, requires Event.edit
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_requires_session(
+    client: KanaeTestClient, route: str
+) -> None:
+    response = await client.client.post(
+        f"/events/{uuid.uuid4()}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_without_edit_permission(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    fake_ory.login_as()
+    response = await client.client.post(
+        f"/events/{uuid.uuid4()}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_bad_hash(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/{route}",
+        json={"hash": "not-hex-64", "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_requires_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+@pytest.mark.parametrize("content_type", ["video/mp4", "application/pdf"])
+async def test_thumbnail_flow_rejects_non_image(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str, content_type: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": content_type, "size": 1024},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_zero_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 0},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_oversized(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/{route}",
+        json={
+            "hash": _VALID_HASH,
+            "content_type": "image/png",
+            "size": _OVERSIZED_THUMBNAIL,
+        },
+    )
+    assert response.status_code == 413
+
+
+async def test_thumbnail_upload_presigns_unknown_hash(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = await _insert_event(kanae.pool, name="thumb-presign")
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    # SimpleUploadResponse — a bare presigned PUT target, no record fields.
+    assert set(body) == {"url"}
+    assert body["url"]
+
+
+async def test_thumbnail_upload_never_consults_the_event_row(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = uuid.uuid4()
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+
+async def test_thumbnail_upload_returns_existing_record(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = await _insert_event(kanae.pool, name="thumb-dedupe")
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+    await _insert_media(kanae.pool, media_hash=_VALID_HASH, size=2048)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 2048},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["hash"] == _VALID_HASH
+    assert body["kind"] == "image"
+    assert body["size"] == 2048
+    assert body["url"]
+
+
+async def test_thumbnail_upload_existing_record_wins_over_declared_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = await _insert_event(kanae.pool, name="thumb-db-wins")
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+    await _insert_media(
+        kanae.pool, media_hash=_VALID_HASH, content_type="image/jpeg", size=4096
+    )
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["size"] == 4096
+    assert body["content_type"] == "image/jpeg"
+
+
+async def test_thumbnail_upload_does_not_set_thumbnail(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    event_id = await _insert_event(kanae.pool, name="thumb-not-set")
+    await fake_ory.grant("Event", str(event_id), "edit", identity_id)
+    await _insert_media(kanae.pool, media_hash=_VALID_HASH)
+
+    response = await client.client.post(
+        f"/events/{event_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    thumbnail_hash = await kanae.pool.fetchval(
+        "SELECT thumbnail_hash FROM events WHERE id = $1", event_id
+    )
+    assert thumbnail_hash is None

--- a/tests/test_media_validation.py
+++ b/tests/test_media_validation.py
@@ -9,7 +9,12 @@ from hypothesis import (
     strategies as st,
 )
 
-from core import ALLOWED_IMAGE_TYPES, ALLOWED_VIDEO_TYPES
+from core import (
+    _MAX_THUMBNAIL_SIZE,
+    ALLOWED_IMAGE_TYPES,
+    ALLOWED_VIDEO_TYPES,
+    validate_thumbnail,
+)
 from routes.projects import (
     _MAX_IMAGE_SIZE,
     _MAX_VIDEO_SIZE,
@@ -29,6 +34,11 @@ _DISALLOWED_FIXED: tuple[str, ...] = (
     "application/octet-stream",
     "",
 )
+
+
+# ══════════════════════════════════════════════════════════════════
+# _validate_media — the general media gate on /media/upload+commit.
+# ══════════════════════════════════════════════════════════════════
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -193,4 +203,131 @@ def test_image_oversize_always_413(content_type: str, size: int) -> None:
 def test_video_oversize_always_413(content_type: str, size: int) -> None:
     with pytest.raises(HTTPException) as exc_info:
         _validate_media(content_type, size)
+    assert exc_info.value.status_code == 413
+
+
+# ══════════════════════════════════════════════════════════════════
+# validate_thumbnail — the narrower gate on the thumbnail
+# upload/commit flow. Images only, one cap, no per-kind branch.
+# ══════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("content_type", sorted(ALLOWED_IMAGE_TYPES))
+@pytest.mark.parametrize(
+    "size",
+    [
+        1,
+        _MAX_THUMBNAIL_SIZE - 1,
+        _MAX_THUMBNAIL_SIZE,
+    ],
+)
+def test_thumbnail_size_within_limit_passes(content_type: str, size: int) -> None:
+    assert validate_thumbnail(content_type, size) is None
+
+
+@pytest.mark.parametrize("content_type", sorted(ALLOWED_IMAGE_TYPES))
+@pytest.mark.parametrize(
+    "size",
+    [
+        _MAX_THUMBNAIL_SIZE + 1,
+        _MAX_THUMBNAIL_SIZE * 2,
+    ],
+)
+def test_thumbnail_size_over_limit_raises_413(content_type: str, size: int) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_thumbnail(content_type, size)
+    assert exc_info.value.status_code == 413
+
+
+@pytest.mark.parametrize("content_type", sorted(ALLOWED_IMAGE_TYPES))
+@pytest.mark.parametrize("size", [0, -1, -(2**31)])
+def test_thumbnail_non_positive_size_raises_bad_request(
+    content_type: str, size: int
+) -> None:
+    with pytest.raises(BadRequestError):
+        validate_thumbnail(content_type, size)
+
+
+# ──────────────────────────────────────────────────────────────────
+# Content-type handling — where this validator deliberately diverges
+# from `_validate_media`.
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("content_type", sorted(ALLOWED_VIDEO_TYPES))
+@pytest.mark.parametrize("size", [1, 1024, _MAX_THUMBNAIL_SIZE])
+def test_thumbnail_video_rejected_as_bad_request(content_type: str, size: int) -> None:
+    with pytest.raises(BadRequestError) as exc_info:
+        validate_thumbnail(content_type, size)
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize("content_type", _DISALLOWED_FIXED)
+def test_thumbnail_disallowed_content_type_raises_400_not_415(
+    content_type: str,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_thumbnail(content_type, 1024)
+    assert exc_info.value.status_code == 400
+
+
+def test_thumbnail_content_type_checked_before_size() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_thumbnail("video/mp4", _MAX_THUMBNAIL_SIZE * 4)
+    assert exc_info.value.status_code == 400
+
+
+@given(
+    content_type=st.text(min_size=0, max_size=200),
+    size=st.integers(min_value=-(2**62), max_value=2**62),
+)
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_thumbnail_validator_terminates_in_a_known_outcome(
+    content_type: str, size: int
+) -> None:
+    try:
+        validate_thumbnail(content_type, size)
+    except HTTPException:
+        return
+    assert content_type in ALLOWED_IMAGE_TYPES
+    assert 0 < size <= _MAX_THUMBNAIL_SIZE
+
+
+@given(
+    content_type=st.text(min_size=1, max_size=200).filter(
+        lambda value: value not in ALLOWED_IMAGE_TYPES
+    ),
+    size=st.integers(min_value=1, max_value=_MAX_THUMBNAIL_SIZE),
+)
+@settings(
+    max_examples=100,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+def test_thumbnail_arbitrary_non_image_rejected_400(
+    content_type: str, size: int
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_thumbnail(content_type, size)
+    assert exc_info.value.status_code == 400
+
+
+@given(
+    content_type=st.sampled_from(sorted(ALLOWED_IMAGE_TYPES)),
+    size=st.integers(
+        min_value=_MAX_THUMBNAIL_SIZE + 1, max_value=_MAX_THUMBNAIL_SIZE * 8
+    ),
+)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_thumbnail_image_oversize_always_413(content_type: str, size: int) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        validate_thumbnail(content_type, size)
     assert exc_info.value.status_code == 413

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -9,8 +9,10 @@ import hiro
 import pytest
 from conftest import FakeOryClient, KanaeTestClient
 
-from core import Kanae
+from core import _MAX_THUMBNAIL_SIZE, Kanae
 from utils.checks import Role
+
+_OVERSIZED_THUMBNAIL = _MAX_THUMBNAIL_SIZE + 1
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -87,6 +89,42 @@ async def _link_project_member(
         project_id,
         member_id,
         role,
+    )
+
+
+async def _insert_media(
+    pool: asyncpg.Pool,
+    *,
+    media_hash: str,
+    content_type: str = "image/png",
+    size: int = 1024,
+    creator_id: uuid.UUID | str | None = None,
+) -> None:
+    # `kind` is a generated column derived from content_type, so it's omitted.
+    await pool.execute(
+        """
+        INSERT INTO media (hash, content_type, size, creator_id)
+        VALUES ($1, $2, $3, $4)
+        """,
+        media_hash,
+        content_type,
+        size,
+        creator_id,
+    )
+
+
+async def _project_media_linked(
+    pool: asyncpg.Pool, project_id: uuid.UUID, media_hash: str
+) -> bool:
+    return await pool.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM project_media
+            WHERE project_id = $1 AND media_hash = $2
+        )
+        """,
+        project_id,
+        media_hash,
     )
 
 
@@ -1171,6 +1209,220 @@ async def test_remove_thumbnail_returns_404_when_missing(
 
     response = await client.client.delete(f"/projects/{missing}/thumbnail")
     assert response.status_code == 404
+
+
+# ──────────────────────────────────────────────────────────────────
+# Thumbnail upload and commit, auth + edit permission
+# ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_requires_session(
+    client: KanaeTestClient, route: str
+) -> None:
+    response = await client.client.post(
+        f"/projects/{uuid.uuid4()}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_without_edit_permission(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    fake_ory.login_as()
+    response = await client.client.post(
+        f"/projects/{uuid.uuid4()}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_bad_hash(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/{route}",
+        json={"hash": "not-hex-64", "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_requires_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+@pytest.mark.parametrize("content_type", ["video/mp4", "application/pdf"])
+async def test_thumbnail_flow_rejects_non_image(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str, content_type: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": content_type, "size": 1024},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_zero_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/{route}",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 0},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("route", ["upload", "commit"])
+async def test_thumbnail_flow_rejects_oversized(
+    client: KanaeTestClient, fake_ory: FakeOryClient, route: str
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/{route}",
+        json={
+            "hash": _VALID_HASH,
+            "content_type": "image/png",
+            "size": _OVERSIZED_THUMBNAIL,
+        },
+    )
+    assert response.status_code == 413
+
+
+async def test_thumbnail_and_media_upload_disagree_on_non_image_status(
+    client: KanaeTestClient, fake_ory: FakeOryClient
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = uuid.uuid4()
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    payload: dict[str, Any] = {
+        "hash": _VALID_HASH,
+        "content_type": "application/pdf",
+        "size": 1024,
+    }
+
+    media = await client.client.post(
+        f"/projects/{project_id}/media/upload", json=payload
+    )
+    thumbnail = await client.client.post(
+        f"/projects/{project_id}/thumbnail/upload", json=payload
+    )
+
+    assert media.status_code == 415
+    assert thumbnail.status_code == 400
+
+
+async def test_thumbnail_upload_presigns_unknown_hash(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="thumb-presign")
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert set(body) == {"url"}
+    assert body["url"]
+
+
+async def test_thumbnail_upload_returns_existing_record_and_links_it(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="thumb-dedupe")
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+    await _insert_media(kanae.pool, media_hash=_VALID_HASH, size=2048)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 2048},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["hash"] == _VALID_HASH
+    assert body["kind"] == "image"
+    assert body["size"] == 2048
+    assert body["url"]
+
+    assert await _project_media_linked(kanae.pool, project_id, _VALID_HASH)
+
+
+async def test_thumbnail_upload_existing_record_wins_over_declared_size(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="thumb-db-wins")
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+    await _insert_media(
+        kanae.pool, media_hash=_VALID_HASH, content_type="image/jpeg", size=4096
+    )
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["size"] == 4096
+    assert body["content_type"] == "image/jpeg"
+
+
+async def test_thumbnail_upload_does_not_set_thumbnail(
+    client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
+) -> None:
+    identity_id = fake_ory.login_as()
+    project_id = await _insert_project(kanae.pool, name="thumb-not-set")
+    await fake_ory.grant("Project", str(project_id), "edit", identity_id)
+    await _insert_media(kanae.pool, media_hash=_VALID_HASH)
+
+    response = await client.client.post(
+        f"/projects/{project_id}/thumbnail/upload",
+        json={"hash": _VALID_HASH, "content_type": "image/png", "size": 1024},
+    )
+    assert response.status_code == 200
+
+    thumbnail_hash = await kanae.pool.fetchval(
+        "SELECT thumbnail_hash FROM projects WHERE id = $1", project_id
+    )
+    assert thumbnail_hash is None
 
 
 # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Summary

Apparently we didn't have this...

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
