### PR TITLE
Fix project thumbnails existing in project media

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         condition: service_completed_successfully
       migrate:
         condition: service_completed_successfully
-    healthcheck: 
+    healthcheck:
       test: curl -fsS --max-time 2 http://127.0.0.1:8000
       interval: 3s
       timeout: 5s

--- a/scripts/test-images.sh
+++ b/scripts/test-images.sh
@@ -802,12 +802,17 @@ STAGED_PROJ_HASH=$(jq -r '.thumbnail.hash // empty' <<<"$STAGED_PROJ")
 	|| fail "project thumbnail is $STAGED_PROJ_HASH, expected $STAGED_HASH"
 ok "project.thumbnail.hash matches the commit response"
 
-# The commit also re-linked the source into project_media, so the reaped hash
-# is back in the project's media list.
+# The commit re-inserted the source into `media` (which is what lets step 34
+# take the dedup branch) but deliberately left project_media alone, so the
+# reaped hash must NOT be back in the project's gallery. A thumbnail source is
+# not gallery content.
 STAGED_LIST=$(curl -s -b "$COOKIES" "$KANAE/projects/$PROJECT_ID/media")
-jq -e --arg h "$THUMB_SRC_HASH" 'any(.[]; .hash == $h)' <<<"$STAGED_LIST" >/dev/null \
-	|| fail "commit did not re-link the source media: $STAGED_LIST"
-ok "commit re-linked the source into project_media"
+# An `... && fail` one-liner would abort under `set -e` on the passing path, so
+# the negative assertion is spelled out as an if.
+if jq -e --arg h "$THUMB_SRC_HASH" 'any(.[]; .hash == $h)' <<<"$STAGED_LIST" >/dev/null; then
+	fail "commit linked the source into project_media: $STAGED_LIST"
+fi
+ok "commit left the source out of project_media"
 
 STAGED_CHECK=$(curl -s -o /dev/null -w "$CURL_HTTP_CODE %{content_type}" "$STAGED_URL")
 STAGED_STATUS="${STAGED_CHECK%% *}"

--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -1598,20 +1598,12 @@ async def upload_project_thumbnail(
     validate_thumbnail(req.content_type, req.size)
 
     query = """
-    WITH media_exists AS (
-        SELECT hash, content_type, kind, size, created_at
-        FROM media
-        WHERE hash = $1
-    ),
-    link AS (
-        INSERT INTO project_media (project_id, media_hash)
-        SELECT $2, hash FROM media_exists
-        ON CONFLICT DO NOTHING
-    )
-    SELECT hash, content_type, kind, size, created_at FROM media_exists;
+    SELECT hash, content_type, kind, size, created_at
+    FROM media
+    WHERE hash = $1;
     """
 
-    exists = await request.app.pool.fetchrow(query, req.hash, project_id)
+    exists = await request.app.pool.fetchrow(query, req.hash)
     if exists:
         url = await request.app.storage.get_url(exists["hash"], exists["content_type"])
         return MediaRecord(**dict(exists), url=url)
@@ -1665,10 +1657,6 @@ async def commit_project_thumbnail(
             ON CONFLICT (hash) DO UPDATE
                 SET hash = EXCLUDED.hash
             RETURNING hash
-        ), link AS (
-            INSERT INTO project_media (project_id, media_hash)
-            SELECT $5, hash FROM insert_media
-            ON CONFLICT DO NOTHING
         ), locked AS (
             SELECT thumbnail_hash FROM projects
             WHERE id = $5

--- a/tests/integration/scenarios/43_thumbnail_upload_commit_matrix.hurl
+++ b/tests/integration/scenarios/43_thumbnail_upload_commit_matrix.hurl
@@ -12,10 +12,10 @@
 #
 # Dummy UUIDs with no DB row stand in for a real project/event, as in 25/26 —
 # Keto grants alone let every auth-gated path be reached. That works here
-# because neither upload route needs the resource row:
-#   - projects: the project_media link is inserted only when the hash already
-#     exists in `media`, and none of these hashes do
-#   - events: there is no bridge table at all, so `events` is never consulted
+# because neither upload route needs the resource row: both are a bare lookup
+# against `media` keyed on the hash alone. Neither attaches what it finds — a
+# thumbnail source is not gallery content, so the project route deliberately
+# leaves project_media untouched, and events have no bridge table at all.
 #
 # Phase ordering follows the same dependency chain as 25/26: session check →
 # Keto check (raw path string, before UUID coercion) → Pydantic → handler.

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1361,7 +1361,7 @@ async def test_thumbnail_upload_presigns_unknown_hash(
     assert body["url"]
 
 
-async def test_thumbnail_upload_returns_existing_record_and_links_it(
+async def test_thumbnail_upload_returns_existing_record_without_linking(
     client: KanaeTestClient, fake_ory: FakeOryClient, kanae: Kanae
 ) -> None:
     identity_id = fake_ory.login_as()
@@ -1381,7 +1381,7 @@ async def test_thumbnail_upload_returns_existing_record_and_links_it(
     assert body["size"] == 2048
     assert body["url"]
 
-    assert await _project_media_linked(kanae.pool, project_id, _VALID_HASH)
+    assert not await _project_media_linked(kanae.pool, project_id, _VALID_HASH)
 
 
 async def test_thumbnail_upload_existing_record_wins_over_declared_size(


### PR DESCRIPTION
# Summary

Apparently, we were linking our thumbnails into `project_media`, making it visible in the gallery and all project media. This just fixes that.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
