### PR TITLE
Add mailpit as SMTP courier for Kratos

### DIFF
--- a/docker/ory/config/kratos/kratos.yml
+++ b/docker/ory/config/kratos/kratos.yml
@@ -141,6 +141,12 @@ selfservice:
     lookup_secret:
       enabled: true
 
+courier:
+  smtp:
+    connection_uri: smtp://mailpit:1025/?disable_starttls=true
+    from_address: noreply@kanae.test
+    from_name: ACM @ UC Merced (dev)
+
 # Placeholders only. Kratos doesn't expand `${VAR}` inside YAML, so the real
 # values must come from env-path overrides set in docker-compose:
 #   SECRETS_COOKIE: <hex from `openssl rand -hex 64`>

--- a/docker/ory/docker-compose.yml
+++ b/docker/ory/docker-compose.yml
@@ -101,3 +101,20 @@ services:
       keto-migrate:
         condition: service_completed_successfully
     restart: unless-stopped
+
+  mailpit:
+    <<: *hard
+    container_name: kanae_mailpit
+    image: axllent/mailpit:latest
+    ports:
+      - "127.0.0.1:8025:8025"
+      - "127.0.0.1:1025:1025"
+    networks:
+      - default
+    healthcheck:
+      test: /mailpit readyz
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      start_interval: 1s
+    restart: unless-stopped


### PR DESCRIPTION
# Summary

Adds in mailpit for dev for our SMTP needs (mainly for recovery and verification). Note that in production, mailpit is not used and an production-ready service such as Postmark or Mailtrap must be used instead.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
