### PR TITLE
Fix `whoami` checks for sessions requiring 2FA

### DIFF
--- a/src/utils/ory.py
+++ b/src/utils/ory.py
@@ -221,7 +221,7 @@ class OryClient:
             "GET", url, headers={"cookie": f"ory_kratos_session={cookie}"}
         )
 
-        if response.status == status.HTTP_401_UNAUTHORIZED:
+        if response.status in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN):
             await response.release()
 
             return None


### PR DESCRIPTION
# Summary

Currently, our `required_all` setting within Kratos requires `highest_available`. This requires the user to have 2FA enrolled. Now in the case of a user having 2FA enabled when resetting a password, our recovery session issues a `aal1` (without 2FA) session, but every endpoint requires `aal2` (with 2FA) session. So, the resulting output is incorrect as it gives a Pydantic validation error; which results in a 500 error due to the crash as seen below:

```
ValidationError: 7 validation errors for KanaeSession

id

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

active

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

expires_at

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

authenticated_at

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

authenticator_assurance_level

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

issued_at

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing

identity

  Field required [type=missing, input_value={'error': {'id': 'session...login/browser?aal=aal2'}, input_type=dict]

    For further information visit https://errors.pydantic.dev/2.13/v/missing
```

So we just ignore it as it's an error.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
