### PR TITLE
Revoke active sessions for password changes

### DIFF
--- a/docker/ory/config/kratos/kratos.prod.yml
+++ b/docker/ory/config/kratos/kratos.prod.yml
@@ -73,6 +73,7 @@ selfservice:
       after:
         password:
           hooks:
+            - hook: revoke_active_sessions
             - hook: web_hook
               config:
                 url: http://kanae:8000/member/webhooks/settings

--- a/docker/ory/config/kratos/kratos.yml
+++ b/docker/ory/config/kratos/kratos.yml
@@ -68,6 +68,7 @@ selfservice:
       after:
         password:
           hooks:
+            - hook: revoke_active_sessions
             - hook: web_hook
               config:
                 url: http://host.docker.internal:8000/member/webhooks/settings


### PR DESCRIPTION
# Summary

Currently, for password resets/changes, it survives the current session. This may leave a valid session token open to potential attacks, so we will invalid the active session when a password is changed or reset.
## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [x] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
