### PR TITLE
Fix broken Kratos config via reordering `revoke_active_sessions` hook

### DIFF
--- a/docker/ory/config/kratos/kratos.prod.yml
+++ b/docker/ory/config/kratos/kratos.prod.yml
@@ -73,7 +73,6 @@ selfservice:
       after:
         password:
           hooks:
-            - hook: revoke_active_sessions
             - hook: web_hook
               config:
                 url: http://kanae:8000/member/webhooks/settings
@@ -87,6 +86,10 @@ selfservice:
                     in: header
                     name: X-Webhook-Token
                     value: ${KRATOS_WEBHOOK_TOKEN_SETTINGS}
+
+            # Sign out every other session of the identity once the password
+            # has been changed.
+            - hook: revoke_active_sessions
         profile:
           hooks:
             - hook: web_hook

--- a/docker/ory/config/kratos/kratos.prod.yml
+++ b/docker/ory/config/kratos/kratos.prod.yml
@@ -87,8 +87,6 @@ selfservice:
                     name: X-Webhook-Token
                     value: ${KRATOS_WEBHOOK_TOKEN_SETTINGS}
 
-            # Sign out every other session of the identity once the password
-            # has been changed.
             - hook: revoke_active_sessions
         profile:
           hooks:

--- a/docker/ory/config/kratos/kratos.yml
+++ b/docker/ory/config/kratos/kratos.yml
@@ -68,7 +68,6 @@ selfservice:
       after:
         password:
           hooks:
-            - hook: revoke_active_sessions
             - hook: web_hook
               config:
                 url: http://host.docker.internal:8000/member/webhooks/settings
@@ -82,6 +81,10 @@ selfservice:
                     in: header
                     name: X-Webhook-Token
                     value: ${KRATOS_WEBHOOK_TOKEN_SETTINGS}
+
+            # Sign out every other session of the identity once the password
+            # has been changed.
+            - hook: revoke_active_sessions
         profile:
           hooks:
             - hook: web_hook

--- a/docker/ory/config/kratos/kratos.yml
+++ b/docker/ory/config/kratos/kratos.yml
@@ -82,8 +82,6 @@ selfservice:
                     name: X-Webhook-Token
                     value: ${KRATOS_WEBHOOK_TOKEN_SETTINGS}
 
-            # Sign out every other session of the identity once the password
-            # has been changed.
             - hook: revoke_active_sessions
         profile:
           hooks:


### PR DESCRIPTION
# Summary

Apparently it should go on the bottom, not the top...

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
