### PR TITLE
Support listing media in project details

### DIFF
--- a/src/routes/projects.py
+++ b/src/routes/projects.py
@@ -90,6 +90,29 @@ class Projects(BaseModel, frozen=True):
     founded_at: datetime.datetime
 
 
+class ProjectDetails(BaseModel, frozen=True):
+    id: uuid.UUID
+    name: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    description: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    link: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
+    thumbnail: Optional[ProjectThumbnail] = None
+    media: list[MediaRecord]
+    members: list[ProjectMember]
+    type: Literal[
+        "independent",
+        "sig_ai",
+        "sig_swe",
+        "sig_cyber",
+        "sig_data",
+        "sig_arch",
+        "sig_graph",
+    ]
+    tags: Optional[list[Annotated[str, Field(pattern=_NO_NULL_REGEX)]]] = None
+    active: bool
+    join_policy: Literal["open", "request", "closed"]
+    founded_at: datetime.datetime
+
+
 class FullProjects(BaseModel, frozen=True):
     id: uuid.UUID
     name: Annotated[str, Field(pattern=_NO_NULL_REGEX)]
@@ -261,9 +284,9 @@ async def list_all_project_invites(
 
 @router.get(
     "/projects/{project_id}",
-    responses={200: {"model": FullProjects}, 404: {"model": NotFoundResponse}},
+    responses={200: {"model": ProjectDetails}, 404: {"model": NotFoundResponse}},
 )
-async def get_project(request: RouteRequest, project_id: uuid.UUID) -> FullProjects:
+async def get_project(request: RouteRequest, project_id: uuid.UUID) -> ProjectDetails:
     """Retrieve project details via ID"""
     query = """
     SELECT
@@ -276,6 +299,21 @@ async def get_project(request: RouteRequest, project_id: uuid.UUID) -> FullProje
             JOIN tags ON tags.id = project_tags.tag_id
             WHERE project_tags.project_id = projects.id
         ) AS tags,
+        COALESCE((
+            SELECT jsonb_agg(
+                jsonb_build_object(
+                    'hash', media.hash,
+                    'content_type', media.content_type,
+                    'kind', media.kind,
+                    'size', media.size,
+                    'created_at', media.created_at
+                )
+                ORDER BY project_media.position NULLS LAST, project_media.created_at
+            )
+            FROM project_media
+            JOIN media ON media.hash = project_media.media_hash
+            WHERE project_media.project_id = projects.id
+        ), '[]'::jsonb) AS project_media,
         CASE WHEN projects.thumbnail_hash IS NOT NULL THEN
             jsonb_build_object(
                 'hash', projects.thumbnail_hash,
@@ -294,7 +332,28 @@ async def get_project(request: RouteRequest, project_id: uuid.UUID) -> FullProje
     )
     if not rows:
         raise NotFoundError
-    return FullProjects(**dict(rows))
+
+    urls = await asyncio.gather(
+        *(
+            request.app.storage.get_url(row["hash"], row["content_type"])
+            for row in rows["project_media"]
+        )
+    )
+
+    return ProjectDetails(
+        **dict(rows),
+        media=[
+            MediaRecord(
+                hash=row["hash"],
+                content_type=row["content_type"],
+                kind=row["kind"],
+                size=row["size"],
+                created_at=row["created_at"],
+                url=url,
+            )
+            for row, url in zip(rows["project_media"], urls, strict=True)
+        ],
+    )
 
 
 class ModifiedProject(BaseModel, frozen=True):

--- a/tests/integration/scenarios/15_project_create_manager.hurl
+++ b/tests/integration/scenarios/15_project_create_manager.hurl
@@ -42,8 +42,10 @@ jsonpath "$.type" == "sig_swe"
 jsonpath "$.active" == true
 jsonpath "$.founded_at" isIsoDate
 
-# Cross-component check: /projects/{id} returns FullProjects which
-# includes the auto-inserted lead row in `members`.
+# Cross-component check: /projects/{id} returns ProjectDetails, which
+# includes the auto-inserted lead row in `members` plus the project's
+# resolved `media`. Nothing has been uploaded here, so the COALESCE
+# fallback in the media subquery yields an empty collection, not null.
 GET {{KANAE_URL}}/projects/{{project_id}}
 HTTP 200
 [Asserts]
@@ -52,6 +54,8 @@ jsonpath "$.members" isCollection
 jsonpath "$.members" count == 1
 jsonpath "$.members[0].id" == "{{MANAGER_ID}}"
 jsonpath "$.members[0].name" isString
+jsonpath "$.media" isCollection
+jsonpath "$.media" count == 0
 
 # /members/me/projects reflects the auto-membership.
 GET {{KANAE_URL}}/members/me/projects
@@ -60,9 +64,12 @@ HTTP 200
 jsonpath "$" isCollection
 body contains "{{project_id}}"
 
-# Visible in the listing.
+# Visible in the listing. list_projects returns FullProjects, a model
+# distinct from ProjectDetails: resolving media costs a presigned URL per
+# entry, so the list endpoint deliberately carries no `media` key at all.
 GET {{KANAE_URL}}/projects?page=1&size=100
 HTTP 200
 [Asserts]
 jsonpath "$.data" isCollection
 body contains "{{project_id}}"
+jsonpath "$.data[0].media" not exists

--- a/tests/integration/scenarios/17_project_lifecycle.hurl
+++ b/tests/integration/scenarios/17_project_lifecycle.hurl
@@ -45,6 +45,8 @@ HTTP 200
 [Asserts]
 jsonpath "$.data" isCollection
 body contains "{{project_id}}"
+# FullProjects (list) vs ProjectDetails (single fetch): no `media` here.
+jsonpath "$.data[0].media" not exists
 
 # Grant Project.edit + Project.own BEFORE the first mutation, so no
 # cached False sits on either tuple in Kanae's permission cache.
@@ -82,6 +84,10 @@ jsonpath "$.name" == "scenario18-renamed"
 jsonpath "$.description" == "edited"
 # Freshly-created project has no tags yet.
 jsonpath "$.tags" == null
+# `media` comes from its own correlated subquery, so it is unaffected by the
+# edit and stays an empty collection (COALESCE fallback) rather than null.
+jsonpath "$.media" isCollection
+jsonpath "$.media" count == 0
 
 # Overwrite the tag set (Project.edit) with the tags bulk-created in
 # scenario 08. Sent out of order with a duplicate; the response echoes the
@@ -97,12 +103,14 @@ jsonpath "$.tags[0]" == "scenario09-alpha"
 jsonpath "$.tags[1]" == "scenario09-beta"
 jsonpath "$.tags[2]" == "scenario09-gamma"
 
-# GET surfaces them, alphabetically (array_agg ORDER BY title).
+# GET surfaces them, alphabetically (array_agg ORDER BY title). The media
+# subquery sits alongside the tags one without disturbing it.
 GET {{KANAE_URL}}/projects/{{project_id}}
 HTTP 200
 [Asserts]
 jsonpath "$.tags" count == 3
 jsonpath "$.tags" contains "scenario09-gamma"
+jsonpath "$.media" count == 0
 
 # Partial removal rides on the overwrite: resend only the survivors.
 PUT {{KANAE_URL}}/projects/{{project_id}}/tags

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -113,6 +113,24 @@ async def _insert_media(
     )
 
 
+async def _link_project_media(
+    pool: asyncpg.Pool,
+    *,
+    project_id: uuid.UUID,
+    media_hash: str,
+    position: int | None = None,
+) -> None:
+    await pool.execute(
+        """
+        INSERT INTO project_media (project_id, media_hash, position)
+        VALUES ($1, $2, $3)
+        """,
+        project_id,
+        media_hash,
+        position,
+    )
+
+
 async def _project_media_linked(
     pool: asyncpg.Pool, project_id: uuid.UUID, media_hash: str
 ) -> bool:
@@ -214,6 +232,11 @@ async def test_list_projects_returns_seeded_rows(
         kanae.pool, project_id=project_b, member_id=member_id, role="member"
     )
 
+    await _insert_media(kanae.pool, media_hash="a" * 64)
+    await _link_project_media(
+        kanae.pool, project_id=project_a, media_hash="a" * 64, position=0
+    )
+
     response = await client.client.get("/projects")
     assert response.status_code == 200
     body: dict[str, Any] = response.json()
@@ -270,20 +293,128 @@ async def test_get_project_returns_404_when_missing(client: KanaeTestClient) -> 
     assert response.status_code == 404
 
 
-async def test_get_project_returns_row(client: KanaeTestClient, kanae: Kanae) -> None:
+@pytest.mark.parametrize("media_count", [0, 3])
+async def test_get_project_returns_row(
+    client: KanaeTestClient, kanae: Kanae, media_count: int
+) -> None:
+    lead_id = uuid.uuid4()
     member_id = uuid.uuid4()
-    await _insert_member(kanae.pool, member_id=member_id)
+    await _insert_member(
+        kanae.pool, member_id=lead_id, name="Lead", email="lead@test.local"
+    )
+    await _insert_member(
+        kanae.pool, member_id=member_id, name="Member", email="member@test.local"
+    )
     project_id = await _insert_project(kanae.pool, name="solo")
     await _link_project_member(
-        kanae.pool, project_id=project_id, member_id=member_id, role="lead"
+        kanae.pool, project_id=project_id, member_id=lead_id, role="lead"
     )
+    await _link_project_member(
+        kanae.pool, project_id=project_id, member_id=member_id, role="member"
+    )
+
+    hashes = [f"{position:064x}" for position in range(media_count)]
+    for position, media_hash in enumerate(hashes):
+        await _insert_media(kanae.pool, media_hash=media_hash)
+        await _link_project_media(
+            kanae.pool,
+            project_id=project_id,
+            media_hash=media_hash,
+            position=position,
+        )
 
     response = await client.client.get(f"/projects/{project_id}")
     assert response.status_code == 200
     body: dict[str, Any] = response.json()
     assert body["id"] == str(project_id)
     assert body["name"] == "solo"
-    assert {m["id"] for m in body["members"]} == {str(member_id)}
+
+    assert len(body["members"]) == 2
+    assert {m["id"] for m in body["members"]} == {str(lead_id), str(member_id)}
+
+    assert isinstance(body["media"], list)
+    assert [entry["hash"] for entry in body["media"]] == hashes
+
+    for entry in body["media"]:
+        assert entry["content_type"] == "image/png"
+        assert entry["kind"] == "image"
+        assert entry["size"] == 1024
+        assert entry["created_at"]
+        assert entry["url"].startswith("http")
+        assert entry["hash"] in entry["url"]
+
+
+async def test_get_project_orders_media_by_position(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    member_id = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=member_id)
+    project_id = await _insert_project(kanae.pool, name="ordered-media")
+    await _link_project_member(
+        kanae.pool, project_id=project_id, member_id=member_id, role="lead"
+    )
+
+    seeded = [("c" * 64, 1), ("a" * 64, 0), ("b" * 64, None)]
+    for media_hash, position in seeded:
+        await _insert_media(kanae.pool, media_hash=media_hash)
+        await _link_project_media(
+            kanae.pool,
+            project_id=project_id,
+            media_hash=media_hash,
+            position=position,
+        )
+
+    response = await client.client.get(f"/projects/{project_id}")
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert [entry["hash"] for entry in body["media"]] == ["a" * 64, "c" * 64, "b" * 64]
+
+
+async def test_get_project_excludes_other_projects_media(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    member_id = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=member_id)
+    mine = await _insert_project(kanae.pool, name="mine")
+    theirs = await _insert_project(kanae.pool, name="theirs")
+    for project_id in (mine, theirs):
+        await _link_project_member(
+            kanae.pool, project_id=project_id, member_id=member_id, role="lead"
+        )
+
+    await _insert_media(kanae.pool, media_hash="a" * 64)
+    await _insert_media(kanae.pool, media_hash="b" * 64)
+    await _link_project_media(kanae.pool, project_id=mine, media_hash="a" * 64)
+    await _link_project_media(kanae.pool, project_id=theirs, media_hash="b" * 64)
+
+    response = await client.client.get(f"/projects/{mine}")
+    assert response.status_code == 200
+    # The subquery is correlated on projects.id, so the sibling row must not leak.
+    assert [entry["hash"] for entry in response.json()["media"]] == ["a" * 64]
+
+
+async def test_get_project_surfaces_video_media(
+    client: KanaeTestClient, kanae: Kanae
+) -> None:
+    member_id = uuid.uuid4()
+    await _insert_member(kanae.pool, member_id=member_id)
+    project_id = await _insert_project(kanae.pool, name="with-video")
+    await _link_project_member(
+        kanae.pool, project_id=project_id, member_id=member_id, role="lead"
+    )
+    await _insert_media(
+        kanae.pool, media_hash="a" * 64, content_type="video/mp4", size=2048
+    )
+    await _link_project_media(
+        kanae.pool, project_id=project_id, media_hash="a" * 64, position=0
+    )
+
+    response = await client.client.get(f"/projects/{project_id}")
+    assert response.status_code == 200
+    entry = response.json()["media"][0]
+    assert entry["kind"] == "video"
+    assert entry["content_type"] == "video/mp4"
+    assert entry["size"] == 2048
 
 
 async def test_get_project_rejects_non_uuid(client: KanaeTestClient) -> None:
@@ -481,6 +612,13 @@ async def test_get_project_surfaces_tags(client: KanaeTestClient, kanae: Kanae) 
     for title in ("rust", "python"):
         tag_id = await _insert_tag(kanae.pool, title=title)
         await _link_project_tag(kanae.pool, project_id=project_id, tag_id=tag_id)
+
+    # Linked media must not disturb the tags aggregate, which is its own subquery.
+    media_hash = f"{1:064x}"
+    await _insert_media(kanae.pool, media_hash=media_hash)
+    await _link_project_media(
+        kanae.pool, project_id=project_id, media_hash=media_hash, position=0
+    )
 
     response = await client.client.get(f"/projects/{project_id}")
     assert response.status_code == 200


### PR DESCRIPTION
# Summary

Previously, within our project details (`get_projects`) route, we didn't show the media associated (if any). A separate fetch was needed to get the media, but this separate media route was gated for those who had the permissions of `Projects.view`, so any unauthed user kept on getting 401 errors. Now, this should fix it by properly including the media within the project details.

Note that the `get_projects` route now returns a model of `ProjectDetails`, which is the same as `FullProjects` but just with the media attached.

## Types of changes

What types of changes does your code introduce to Kanae?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (Updates to README.md, the documentation, etc)
- [ ] Other (if none of the other choices apply)

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

_Put an `x` in the boxes that apply_

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes. (if appropriate)
- [x] All workflows pass with my new changes
- [x] This PR does **not** address a duplicate issue or PR
